### PR TITLE
Create new github issue template for security assessments

### DIFF
--- a/.github/ISSUE_TEMPLATE/security-assessment.md
+++ b/.github/ISSUE_TEMPLATE/security-assessment.md
@@ -1,0 +1,36 @@
+---
+name: Security Assessment Request
+about: Request a Security Assessment from SIG Security members for Kubernetes sub-projects
+title: 'REQUEST: Security Assessment for <sub-project-name>'
+labels: area/security-assessment, sig/security
+assignees: 
+---
+
+**Is this a Kubernetes sub-project?** 
+<!--
+A subproject in this context is defined as a repository in https://github.com/kubernetes-sigs/ or https://github.com/kubernetes
+
+For CNCF projects, please refer to CNCF Security TAG process: https://github.com/cncf/tag-security/tree/main/assessments
+-->
+
+**Tell us a bit about your sub-project?** (Please include a link to a draft)
+<!-- Please include links to github repos, docs and communication channels (e.g. mailing list, slack channel) -->
+
+**Do you have a preferred timeline for completing security assessment?**
+  
+<!-- The team looks at these every other week, but if you have an urgent need for this request, please reach out to us on Kubernetes slack: #sig-security 
+
+If you have already identified members in the community who are willing to help out in this initiative please tag them in this issue
+-->
+
+
+<!-- Want to learn more about SIG Security ? 
+
+We started the partnering with maintainers for self-assessments of sub-projects in 2021, to improve security posture and increase awareness of
+security best practices throughout the Kubernetes community
+
+Read about our charter here: https://github.com/kubernetes/community/blob/master/sig-security/charter.md
+
+Have feedback about the process: https://github.com/kubernetes/community/issues/5921
+
+And thanks for reaching out! We're here to help. -->

--- a/.github/ISSUE_TEMPLATE/security-assessment.md
+++ b/.github/ISSUE_TEMPLATE/security-assessment.md
@@ -13,16 +13,20 @@ A subproject in this context is defined as a repository in https://github.com/ku
 For CNCF projects, please refer to CNCF Security TAG process: https://github.com/cncf/tag-security/tree/main/assessments
 -->
 
-**Tell us a bit about your sub-project?** (Please include a link to a draft)
+**Please tell us a bit about your sub-project** 
 <!-- Please include links to github repos, docs and communication channels (e.g. mailing list, slack channel) -->
 
-**Do you have a preferred timeline for completing security assessment?**
+**Do you have a preferred timeline for completing the security assessment?**
   
 <!-- The team looks at these every other week, but if you have an urgent need for this request, please reach out to us on Kubernetes slack: #sig-security 
 
 If you have already identified members in the community who are willing to help out in this initiative please tag them in this issue
 -->
+**Please share any additional or alternate points of contact for this request**
 
+<!-- Atleast one additional point of contact is recommended other than the person creating this issue
+
+-->
 
 <!-- Want to learn more about SIG Security ? 
 
@@ -31,6 +35,6 @@ security best practices throughout the Kubernetes community
 
 Read about our charter here: https://github.com/kubernetes/community/blob/master/sig-security/charter.md
 
-Have feedback about the process: https://github.com/kubernetes/community/issues/5921
+If you have any feedback about this process, please leave a comment here: https://github.com/kubernetes/sig-security/issues/2
 
 And thanks for reaching out! We're here to help. -->


### PR DESCRIPTION
Creates a new security assessment Github issue template for making this a self-service request for any sub-projects

/cc @kubernetes/sig-security-leads @rficcaglia @savitharaghunathan @reylejano 
/sig security 

X-Ref: https://github.com/kubernetes/community/issues/5921