### PR TITLE
Docs for scanning known vulnerabilities in build time dependencies

### DIFF
--- a/sig-security-tooling/vulnerability-mgmt/README.md
+++ b/sig-security-tooling/vulnerability-mgmt/README.md
@@ -1,0 +1,54 @@
+# Vulnerability Management
+
+Covers Kubernetes wide vulnerability management process, policies and workflows
+that tackle *known* vulnerabilities in Kubernetes artifacts that can be found
+via automation
+
+## Goals
+
+1. Identify known vulnerabilities in Kubernetes artifacts by scanning them
+   periodically
+2. Leverage the existing resolution and reporting process (i.e. Github issues, PRs)
+   to document and resolve any vulnerabilities that impact Kubernetes
+3. Create community driven awareness and documentation around known CVEs in
+   Kubernetes related artifacts
+
+### Build Time Dependencies
+
+A tool agnostic periodic scanning of build time dependencies
+(typically dependencies found in `go.mod` file) of Kubernetes. More details can
+be found [here](build-time-dependencies.md)
+
+This track is a partnership between SIG
+Architecture's [Code Organization](https://github.com/kubernetes/community/tree/master/sig-architecture#code-organization)
+sub-project and SIG Security's Tooling sub-project
+
+### Container Images
+
+A tool agnostic periodic scanning for vulnerabilities in container images 
+shipped as part of a Kubernetes Release. This effort is beginning to take form 
+and is being tracked in 
+[Issue #5920](https://github.com/kubernetes/community/issues/5920)
+
+This track is a partnership
+between [SIG Release](https://github.com/kubernetes/sig-release)
+and SIG Security's Tooling sub-project
+
+**Note**: Artifacts here refer to code, images and binaries
+
+## Non-Goals
+
+1. **Responsible disclosure of vulnerabilities**: This will continue to be the
+   responsibility
+   of [Security Response Committee](https://github.com/kubernetes/community/tree/master/committee-product-security/README.md)
+2. **Runtime dependencies**: Triaging of vulnerabilities found in components
+   that are runtime dependencies for an on-premises or *-as-a-service*
+   Kubernetes deployment. Examples include but are not limited to container
+   runtimes, container registries, Node OS
+3. **Resolving license violations**: Allowed third party license policy can be
+   found [here](https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist)
+
+**Note**: If you have a topic that you think is missing, please hop on over to
+our
+[slack channel](https://kubernetes.slack.com/messages/sig-security-tooling)
+to discuss more :-)

--- a/sig-security-tooling/vulnerability-mgmt/build-time-dependencies.md
+++ b/sig-security-tooling/vulnerability-mgmt/build-time-dependencies.md
@@ -1,0 +1,319 @@
+# Periodic scanning for vulnerabilities in build time dependencies
+
+Report vulnerabilities in build time dependencies
+of [Kubernetes](https://github.com/kubernetes/kubernetes) repository
+
+Tracker: [Issue #101528](https://github.com/kubernetes/kubernetes/issues/101528)
+
+## Background and Prior work
+
+The process described here is tooling agnostic i.e. the process can be
+implemented using any scanner with minimal or no changes. This is also _not_ an
+endorsement of any specific tool or scanner. In order to get a working solution
+in place, [snyk](https://snyk.io/) was chosen for following reasons:
+
+1. Existing partnership between CNCF and Snyk helped procure an account that
+   allowed us to scan `kubernetes/kubernetes`
+   repo: https://github.com/kubernetes/steering/issues/206
+2. Snyk has detected vulnerabilities in transient dependencies of
+   `kubernetes/kubernetes`: https://kubernetes.slack.com/archives/CHGFYJVAN/p1595258034095300
+3. Snyk has a programmable interface which made it easier to filter out
+   licensing issues and known false positive vulnerabilities
+
+## Implementation with Snyk
+
+There are two ways to scan the Kubernetes repo for vulnerabilities in
+dependencies at build time
+
+### Running the scan locally
+
+#### Step 0: Install Snyk CLI
+
+Follow these instructions to snyk cli installed on your
+machine: https://support.snyk.io/hc/en-us/articles/360003812538-Install-the-Snyk-CL
+
+#### Step 1: Authenticate
+
+##### Option A :
+
+Running command `snyk auth` takes you to snyk.io website, do signup/login/auth
+
+```
+snyk auth
+```
+
+##### Option B:
+
+Get the API token from https://app.snyk.io/account and use it
+
+```
+snyk auth XXX-XXX-XXX-XXX-XXX
+Your account has been authenticated. Snyk is now ready to be used.
+```
+
+#### Step 2: Run test
+
+```
+# in k/k repo
+snyk test
+```
+
+### Running the scan as part of k/k testgrid
+
+Prow job that runs every 6 hours is located
+here: https://testgrid.k8s.io/sig-security-snyk-scan#ci-kubernetes-snyk-master
+
+#### Improvements to the raw scan results
+
+Raw scan results were useful, but needed some Kubernetes specific work
+
+##### JSON output
+
+To store the json output in a file and let stdout use command line friendly
+output:
+
+```
+snyk test --json-file-output=licenses-cves.json
+```
+
+##### Licenses
+
+Since detecting licensing violations is a non-goal, licenses related results,
+can be removed from the output using this query:
+
+```
+cat licenses-cves.json | jq '.vulnerabilities | .[] | select (.type=="license" | not)' > only_cves.json
+```
+
+##### Removing False Positive CVEs identified with v0.0.0
+
+Since these are really pointing to the code at HEAD in git tracking, we can
+ignore the vulnerabilities that are generated when snyk detects v0.0.0 as
+Kubernetes version because of the way
+[replace](https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive)
+directives are used.
+
+Easy way to remove licensing *and* CVEs like this:
+
+```
+cat licenses-cves.json | jq '.vulnerabilities | .[] | select ((.type=="license") or (.version=="0.0.0") | not)' > only_cves_wo000.json
+```
+
+### Example of filtered JSON scan result
+
+__Note__: Results of the filtered scan are not printed as part of the CI job. 
+However, the following historical scan result is mentioned here for 
+reference purposes only:
+
+<!-- markdownlint-disable MD033 -->
+<details><summary>Click to view result</summary>
+<!-- markdownlint-enable MD033 -->
+
+```
+{
+  "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+  "alternativeIds": [],
+  "creationTime": "2021-02-08T10:27:10.200417Z",
+  "credit": [
+    "Unknown"
+  ],
+  "cvssScore": 7.2,
+  "description": "## Overview\n\nAffected versions of this package are vulnerable to Directory Traversal. When specifying the plugin to load in the `type` field in the network configuration, it is possible to use special elements such as \"../\" separators to reference binaries elsewhere on the system. An attacker can use this to execute other existing binaries other than the cni plugins/types such as `reboot`.\n\n## Details\n\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\n\nDirectory Traversal vulnerabilities can be generally divided into two types:\n\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\n\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\n\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\n\n```\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\n```\n**Note** `%2e` is the URL encoded version of `.` (dot).\n\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \n\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\n\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\n\n```\n2018-04-15 22:04:29 .....           19           19  good.txt\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\n```\n\n## Remediation\nUpgrade `github.com/containernetworking/cni/pkg/invoke` to version 0.8.1 or higher.\n## References\n- [GitHub PR](https://github.com/containernetworking/cni/pull/808)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1919391)\n",
+  "disclosureTime": "2021-02-05T00:00:00Z",
+  "exploit": "Not Defined",
+  "fixedIn": [
+    "0.8.1"
+  ],
+  "functions": [],
+  "functions_new": [],
+  "id": "SNYK-GOLANG-GITHUBCOMCONTAINERNETWORKINGCNIPKGINVOKE-1070549",
+  "identifiers": {
+    "CVE": [
+      "CVE-2021-20206"
+    ],
+    "CWE": [
+      "CWE-22"
+    ]
+  },
+  "language": "golang",
+  "modificationTime": "2021-02-08T14:14:51.744734Z",
+  "moduleName": "github.com/containernetworking/cni/pkg/invoke",
+  "packageManager": "golang",
+  "packageName": "github.com/containernetworking/cni/pkg/invoke",
+  "patches": [],
+  "proprietary": false,
+  "publicationTime": "2021-02-08T14:14:51.968123Z",
+  "references": [
+    {
+      "title": "GitHub PR",
+      "url": "https://github.com/containernetworking/cni/pull/808"
+    },
+    {
+      "title": "RedHat Bugzilla Bug",
+      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1919391"
+    }
+  ],
+  "semver": {
+    "hashesRange": [
+      "<v0.8.1"
+    ],
+    "vulnerable": [
+      "<0.8.1"
+    ],
+    "vulnerableHashes": [<snipped a long list of hashes for brevity>
+    ]
+  },
+  "severity": "high",
+  "severityWithCritical": "high",
+  "title": "Directory Traversal",
+  "from": [
+    "k8s.io/kubernetes@0.0.0",
+    "github.com/containernetworking/cni/libcni@0.8.0",
+    "github.com/containernetworking/cni/pkg/invoke@0.8.0"
+  ],
+  "upgradePath": [],
+  "isUpgradable": false,
+  "isPatchable": false,
+  "name": "github.com/containernetworking/cni/pkg/invoke",
+  "version": "0.8.0"
+}
+{
+  "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+  "alternativeIds": [],
+  "creationTime": "2020-07-30T13:33:31.283115Z",
+  "credit": [
+    "christopher-wong"
+  ],
+  "cvssScore": 7.5,
+  "description": "## Overview\n[github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go) is a go implementation of JSON Web Tokens.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass if `m[\"aud\"]` happens to be `[]string{}`, as allowed by the spec, the type assertion fails and the value of `aud` is `\"\"`. This can cause audience verification to succeed even if the audiences being passed are incorrect if `required` is set to `false`.\n## Remediation\nUpgrade `github.com/dgrijalva/jwt-go` to version 4.0.0-preview1 or higher.\n## References\n- [GitHub Issue](https://github.com/dgrijalva/jwt-go/issues/422)\n- [GitHub PR](https://github.com/dgrijalva/jwt-go/pull/426)\n",
+  "disclosureTime": "2020-07-30T13:22:28Z",
+  "exploit": "Not Defined",
+  "fixedIn": [
+    "4.0.0-preview1"
+  ],
+  "functions": [],
+  "functions_new": [],
+  "id": "SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515",
+  "identifiers": {
+    "CVE": [
+      "CVE-2020-26160"
+    ],
+    "CWE": [
+      "CWE-287"
+    ]
+  },
+  "language": "golang",
+  "modificationTime": "2020-11-30T11:23:07.967004Z",
+  "moduleName": "github.com/dgrijalva/jwt-go",
+  "packageManager": "golang",
+  "packageName": "github.com/dgrijalva/jwt-go",
+  "patches": [],
+  "proprietary": false,
+  "publicationTime": "2020-09-13T15:53:35Z",
+  "references": [
+    {
+      "title": "GitHub Issue",
+      "url": "https://github.com/dgrijalva/jwt-go/issues/422"
+    },
+    {
+      "title": "GitHub PR",
+      "url": "https://github.com/dgrijalva/jwt-go/pull/426"
+    }
+  ],
+  "semver": {
+    "hashesRange": [
+      "v4.0.0-preview1"
+    ],
+    "vulnerable": [
+      "<4.0.0-preview1"
+    ],
+    "vulnerableHashes": null
+  },
+  "severity": "high",
+  "severityWithCritical": "high",
+  "title": "Access Restriction Bypass",
+  "from": [
+    "k8s.io/kubernetes@0.0.0",
+    "github.com/heketi/heketi/client/api/go-client@10.2.0",
+    "github.com/dgrijalva/jwt-go@3.2.0"
+  ],
+  "upgradePath": [],
+  "isUpgradable": false,
+  "isPatchable": false,
+  "name": "github.com/dgrijalva/jwt-go",
+  "version": "3.2.0"
+}
+{
+  "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+  "alternativeIds": [],
+  "creationTime": "2020-07-30T13:33:31.283115Z",
+  "credit": [
+    "christopher-wong"
+  ],
+  "cvssScore": 7.5,
+  "description": "## Overview\n[github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go) is a go implementation of JSON Web Tokens.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass if `m[\"aud\"]` happens to be `[]string{}`, as allowed by the spec, the type assertion fails and the value of `aud` is `\"\"`. This can cause audience verification to succeed even if the audiences being passed are incorrect if `required` is set to `false`.\n## Remediation\nUpgrade `github.com/dgrijalva/jwt-go` to version 4.0.0-preview1 or higher.\n## References\n- [GitHub Issue](https://github.com/dgrijalva/jwt-go/issues/422)\n- [GitHub PR](https://github.com/dgrijalva/jwt-go/pull/426)\n",
+  "disclosureTime": "2020-07-30T13:22:28Z",
+  "exploit": "Not Defined",
+  "fixedIn": [
+    "4.0.0-preview1"
+  ],
+  "functions": [],
+  "functions_new": [],
+  "id": "SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515",
+  "identifiers": {
+    "CVE": [
+      "CVE-2020-26160"
+    ],
+    "CWE": [
+      "CWE-287"
+    ]
+  },
+  "language": "golang",
+  "modificationTime": "2020-11-30T11:23:07.967004Z",
+  "moduleName": "github.com/dgrijalva/jwt-go",
+  "packageManager": "golang",
+  "packageName": "github.com/dgrijalva/jwt-go",
+  "patches": [],
+  "proprietary": false,
+  "publicationTime": "2020-09-13T15:53:35Z",
+  "references": [
+    {
+      "title": "GitHub Issue",
+      "url": "https://github.com/dgrijalva/jwt-go/issues/422"
+    },
+    {
+      "title": "GitHub PR",
+      "url": "https://github.com/dgrijalva/jwt-go/pull/426"
+    }
+  ],
+  "semver": {
+    "hashesRange": [
+      "v4.0.0-preview1"
+    ],
+    "vulnerable": [
+      "<4.0.0-preview1"
+    ],
+    "vulnerableHashes": null
+  },
+  "severity": "high",
+  "severityWithCritical": "high",
+  "title": "Access Restriction Bypass",
+  "from": [
+    "k8s.io/kubernetes@0.0.0",
+    "k8s.io/apiserver/pkg/storage/etcd3/testing@0.0.0",
+    "go.etcd.io/etcd/integration@#dd1b699fc489",
+    "go.etcd.io/etcd/etcdserver/api/v3rpc@#dd1b699fc489",
+    "go.etcd.io/etcd/mvcc@#dd1b699fc489",
+    "go.etcd.io/etcd/auth@#dd1b699fc489",
+    "github.com/dgrijalva/jwt-go@3.2.0"
+  ],
+  "upgradePath": [],
+  "isUpgradable": false,
+  "isPatchable": false,
+  "name": "github.com/dgrijalva/jwt-go",
+  "version": "3.2.0"
+}
+
+```
+
+</details>


### PR DESCRIPTION
(Re)Creating this after the great migration of #9 to document the periodic scanning process for build time dependencies and container images. 

Triage process to be documented will be refactored in future to a KEP. Coming soon!

/sig security architecture release
/area security
/assign IanColdwater tabbysable