### PR TITLE
Documentation for scanning of container images

### DIFF
--- a/sig-security-tooling/vulnerability-mgmt/README.md
+++ b/sig-security-tooling/vulnerability-mgmt/README.md
@@ -28,7 +28,7 @@ sub-project and SIG Security's Tooling sub-project
 A tool agnostic periodic scanning for vulnerabilities in container images 
 shipped as part of a Kubernetes Release. This effort is beginning to take form 
 and is being tracked in 
-[Issue #5920](https://github.com/kubernetes/community/issues/5920)
+[Issue #5920](https://github.com/kubernetes/community/issues/5920). More details can be found [here](container-images.md)
 
 This track is a partnership
 between [SIG Release](https://github.com/kubernetes/sig-release)

--- a/sig-security-tooling/vulnerability-mgmt/container-images.md
+++ b/sig-security-tooling/vulnerability-mgmt/container-images.md
@@ -1,0 +1,180 @@
+# Periodic scanning for vulnerabilities in container images
+
+Report vulnerabilities in container images
+of [Kubernetes](https://github.com/kubernetes/kubernetes) repository
+
+Tracker: [Issue #101528](https://github.com/kubernetes/kubernetes/issues/101528)
+
+## Background and Prior work
+
+The process described here is tooling agnostic i.e. the process can be
+implemented using any scanner with minimal or no changes. This is also _not_ an
+endorsement of any specific tool or scanner. In order to get a working solution
+in place, [snyk](https://snyk.io/) was chosen for following reasons:
+
+1. Existing partnership between CNCF and Snyk helped procure an account that
+   allowed us to scan `kubernetes/kubernetes`
+   repo: https://github.com/kubernetes/steering/issues/206
+2. Snyk has detected vulnerabilities in transient dependencies of
+   `kubernetes/kubernetes`: https://kubernetes.slack.com/archives/CHGFYJVAN/p1595258034095300
+3. Snyk has a programmable interface which made it easier to filter out
+   licensing issues and known false positive vulnerabilities
+
+## Implementation with Snyk
+
+There are two ways to scan the Kubernetes repo for vulnerabilities in
+container images
+
+### Running the scan locally
+
+#### Step 0: Install Snyk CLI
+
+Follow these instructions to snyk cli installed on your
+machine: https://support.snyk.io/hc/en-us/articles/360003812538-Install-the-Snyk-CL
+
+#### Step 1: Authenticate
+
+##### Option A :
+
+Running command `snyk auth` takes you to snyk.io website, do signup/login/auth
+
+```
+snyk auth
+```
+
+##### Option B:
+
+Get the API token from https://app.snyk.io/account and use it
+
+```
+snyk auth XXX-XXX-XXX-XXX-XXX
+Your account has been authenticated. Snyk is now ready to be used.
+```
+
+#### Step 2: Collect list of container images 
+
+```sh
+curl -Ls https://sbom.k8s.io/$(curl -Ls https://dl.k8s.io/release/latest.txt)/release | grep 'PackageName: k8s.gcr.io/' | awk '{print $2}' > images.txt
+```
+
+#### Step 3: Run test
+
+```sh
+while read image; do snyk container test $image -d --json; done < images.txt
+```
+
+### Running the scan as part of k/k testgrid
+
+Prow job that runs every 6 hours is located
+here: https://testgrid.k8s.io/sig-security-snyk-scan#ci-kubernetes-snyk-master
+
+#### Improvements to the raw scan results
+
+Raw scan results were useful, but needed some Kubernetes specific work
+
+##### JSON output
+
+To store the json output in a file and let stdout use command line friendly
+output:
+
+```
+snyk container test --json-file-output=all-cves.json
+```
+
+#####  Fixable Vulnerabilities
+
+To output vulnerabilites able to be triaged, only upgradeable 
+or patchable results can be parsed from the output using this query:
+
+```
+cat all-cves.json | jq '{ vulnerabilities: .vulnerabilities | map(select(.isUpgradable == true or .isPatchable == true)) | select(length > 0) }' > fixable_cves.json
+```
+
+### Example of filtered JSON scan result
+
+__Note__: Results of the filtered scan are not printed as part of the CI job. 
+However, the following historical scan result is mentioned here for 
+reference purposes only:
+
+<!-- markdownlint-disable MD033 -->
+<details><summary>Click to view result</summary>
+<!-- markdownlint-enable MD033 -->
+
+```
+{
+  "title": "Use After Free",
+  "credit": [
+    ""
+  ],
+  "packageName": "glibc",
+  "language": "linux",
+  "packageManager": "debian:11",
+  "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `glibc` package. </i>\n\nThe mq_notify function in the GNU C Library (aka glibc) versions 2.32 and 2.33 has a use-after-free. It may use the notification thread attributes object (passed through its struct sigevent parameter) after it has been freed by the caller, leading to a denial of service (application crash) or possibly unspecified other impact.\n## Remediation\nThere is no fixed version for `Debian:11` `glibc`.\n## References\n- [ADVISORY](https://security-tracker.debian.org/tracker/CVE-2021-33574)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210629-0005/)\n- [FEDORA](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RBUUWUGXVILQXVWEOU7N42ICHPJNAEUP/)\n- [GENTOO](https://security.gentoo.org/glsa/202107-07)\n- [MISC](https://sourceware.org/bugzilla/show_bug.cgi?id=27896)\n- [MISC](https://sourceware.org/bugzilla/show_bug.cgi?id=27896#c1)\n",
+  "identifiers": {
+    "ALTERNATIVE": [],
+    "CVE": [
+      "CVE-2021-33574"
+    ],
+    "CWE": [
+      "CWE-416"
+    ]
+  },
+  "severity": "critical",
+  "severityWithCritical": "critical",
+  "socialTrendAlert": false,
+  "cvssScore": 9.8,
+  "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+  "patches": [],
+  "references": [
+    {
+      "title": "ADVISORY",
+      "url": "https://security-tracker.debian.org/tracker/CVE-2021-33574"
+    },
+    {
+      "title": "CONFIRM",
+      "url": "https://security.netapp.com/advisory/ntap-20210629-0005/"
+    },
+    {
+      "title": "FEDORA",
+      "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RBUUWUGXVILQXVWEOU7N42ICHPJNAEUP/"
+    },
+    {
+      "title": "GENTOO",
+      "url": "https://security.gentoo.org/glsa/202107-07"
+    },
+    {
+      "title": "MISC",
+      "url": "https://sourceware.org/bugzilla/show_bug.cgi?id=27896"
+    },
+    {
+      "title": "MISC",
+      "url": "https://sourceware.org/bugzilla/show_bug.cgi?id=27896%23c1"
+    }
+  ],
+  "creationTime": "2021-05-26T15:11:38.773280Z",
+  "modificationTime": "2021-12-04T14:20:17.969879Z",
+  "publicationTime": "2021-05-26T15:11:38.561943Z",
+  "disclosureTime": "2021-05-25T22:15:00Z",
+  "id": "SNYK-DEBIAN11-GLIBC-1296898",
+  "malicious": false,
+  "nvdSeverity": "critical",
+  "relativeImportance": "not yet assigned",
+  "semver": {
+    "vulnerable": [
+      "*"
+    ]
+  },
+  "exploit": "Not Defined",
+  "from": [
+    "docker-image|k8s.gcr.io/conformance-ppc64le@v1.24.0-alpha.1",
+    "glibc/libc6@2.31-13+deb11u2"
+  ],
+  "upgradePath": [],
+  "isUpgradable": false,
+  "isPatchable": false,
+  "name": "glibc/libc6",
+  "version": "2.31-13+deb11u2"
+}
+```
+
+</details>


### PR DESCRIPTION
Adds documentation equivalent to #16 for container image vulnerability scanning.

/sig security architecture release
/area security