### PR TITLE
Install missing pip3

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-cve-feed.sh
+++ b/sig-security-tooling/cve-feed/hack/fetch-cve-feed.sh
@@ -17,6 +17,10 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+#install python-pip3
+apt-get update
+apt-get install -y python3-pip
+
 #install requests module
 pip3 install requests
 


### PR DESCRIPTION
Since we need to change the image https://github.com/kubernetes/test-infra/pull/26990 for gsutil, the new image does not have pip3 installed

/cc @nehaLohia27 
/sig security testing k8s-infra
/area security