### PR TITLE
Increase default no. of results for Github Search API

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -18,7 +18,10 @@ import json
 import requests
 
 url = 'https://api.github.com/search/issues?q=is:issue+label:official-cve-feed+\
-state:closed+repo:kubernetes/kubernetes'
+state:closed+repo:kubernetes/kubernetes&per_page=100'
+# `per_page` sets the number of results that can be returned without using pagination. Current number of in-scope issues are 38. 
+# Note: When total number of inscope issues are more than 100, it is suggested to use pagination to avoid inconsistent results
+# because of timeouts.
 headers = {'Accept': 'application/vnd.github.v3+json'}
 res = requests.get(url, headers=headers)
 cve_arr = res.json()


### PR DESCRIPTION
Currently in scope issues are 38 whereas the `per_page` default for Github Search API is 30. 

This was resulting in limited results being made available in the feed.  Switched this now to 100 and added a note for future reference

To validate this issue exists, visit these URLs and compare the results you get:

GUI search: https://github.com/kubernetes/kubernetes/issues?page=2&q=is%3Aissue+is%3Aclosed+label%3Aofficial-cve-feed
Default Number of results for search API: https://api.github.com/search/issues?q=type:issue+label:official-cve-feed+state:closed+repo:kubernetes/kubernetes
Increased limit for number of results for search API: https://api.github.com/search/issues?q=type:issue+label:official-cve-feed+state:closed+repo:kubernetes/kubernetes&per_page=100

/kind bug
/cc @nehaLohia27 @mtardy 