### PR TITLE
Improve the CVE feed python script HTTP request

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -22,7 +22,7 @@ state:closed+repo:kubernetes/kubernetes&per_page=100'
 
 headers = {'Accept': 'application/vnd.github.v3+json'}
 res = requests.get(url, headers=headers)
-gh_items = res.json()['items'].copy()
+gh_items = res.json()['items']
 # Use link header to iterate over pages
 # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#pagination
 # https://datatracker.ietf.org/doc/html/rfc5988

--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -19,16 +19,23 @@ import requests
 
 url = 'https://api.github.com/search/issues?q=is:issue+label:official-cve-feed+\
 state:closed+repo:kubernetes/kubernetes&per_page=100'
-# `per_page` sets the number of results that can be returned without using pagination. Current number of in-scope issues are 38. 
-# Note: When total number of inscope issues are more than 100, it is suggested to use pagination to avoid inconsistent results
-# because of timeouts.
+
 headers = {'Accept': 'application/vnd.github.v3+json'}
 res = requests.get(url, headers=headers)
-cve_arr = res.json()
+gh_items = res.json()['items'].copy()
+# Use link header to iterate over pages
+# https://docs.github.com/en/rest/overview/resources-in-the-rest-api#pagination
+# https://datatracker.ietf.org/doc/html/rfc5988
+# Please note that if there is a great number of pages, this unauthenticated
+# request may be subject to rate limits and fail.
+# https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
+while 'next' in res.links:
+    res = requests.get(res.links['next']['url'], headers=headers)
+    gh_items.extend(res.json()['items'])
 
 cve_list = []
 
-for item in cve_arr['items']:
+for item in gh_items:
     cve = {"issue_url": None, "number": None, "cve_id": None,
            "summary": None, "cve_url": None, "google_group_url": None}
     cve['issue_url'] = item['html_url']


### PR DESCRIPTION
I just wrote that in reaction to Pushkar's quick fix https://github.com/kubernetes/sig-security/pull/65, which is completely valid by the way (while the k8s CVEs number is <= 100), I just saw an area for improvement.

The previous implementation ignored all results that exceeded the number of items per page. This implementation uses the link HTTP header to iterate over potential next pages and should be a bit more robust.

If you want to try this to make sure it works on your computer, I suggest changing line 21 to:
```
state:closed+repo:kubernetes/kubernetes&per_page=20'
```
Be careful to not put something like `per_page=2` or Github will rate limit you notably because the request is unauthenticated!

/cc @PushkarJ @nehaLohia27 