### PR TITLE
Fix CVE feed: comply with the JSON feed specifications

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -40,25 +40,23 @@ for item in gh_items:
            "summary": None, "cve_url": None, "google_group_url": None}
     cve['issue_url'] = item['html_url']
     cve['number'] = item['number']
+    # This because some CVEs were titled "CVE-XXXX-XXXX - Something" instead of
+    # "CVE-XXXX-XXXX: Something" on GitHub (see https://github.com/kubernetes/kubernetes/issues/60813).
     title = item['title'].replace(" -", ":")
+    # This splits the CVE into its ID and the description/name, however some are in the following forms:
+    # - CVE-2019-11245: v1.14.2, v1.13.6: container uid [...] (see https://github.com/kubernetes/kubernetes/issues/78308)
+    # - CVE-2019-11250: TOB-K8S-001: Bearer tokens [...] (see https://github.com/kubernetes/kubernetes/issues/81114)
+    # We don't know if there are going to be version numbers and/or vendor IDs but the description should be last.
     title = title.split(": ")
-    if len(title) == 1:
-        cve_id = None
-        cve['cve_id'] = None
-        cve['cve_url'] = None
-        cve['summary'] = title[0]
-        cve['google_group_url'] = None
-    else:
-        cve_id = title[0]
-        cve['cve_id'] = title[0]
-        if len(title) == 3:
-            cve['summary'] = title[2]
-        else:
-            cve['summary'] = title[1]
-        cve['cve_url'] = f"https://www.cve.org/cverecord?id={cve_id}"
-        cve['google_group_url'] = \
-        f"https://groups.google.com/g/kubernetes-announce/search?q={cve_id}"
+    if len(title) > 0:
+        cve['content_text'] = title[-1]
+        if len(title) > 1:
+            cve_id = title[0]
+            cve['cve_id'] = cve_id
+            cve['cve_url'] = f"https://www.cve.org/cverecord?id={cve_id}"
+            cve['google_group_url'] = f"https://groups.google.com/g/kubernetes-announce/search?q={cve_id}"
     cve_list.append(cve)
+
 cves = json.dumps(cve_list, sort_keys=True, indent=4)
 print(cves)
 # write the final cve list to official_cve_feed.json

--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -36,29 +36,35 @@ while 'next' in res.links:
 cve_list = []
 
 for item in gh_items:
-    cve = {"issue_url": None, "number": None, "cve_id": None,
-           "summary": None, "cve_url": None, "google_group_url": None}
-    cve['issue_url'] = item['html_url']
-    cve['number'] = item['number']
+    # These keys respects the item jsonfeed spec https://www.jsonfeed.org/version/1.1/
+    cve = {'url': None, 'id': None, 'summary': None, 'external_url': None,
+    'content_text': None, '_kubernetes_io': None}
+    # This is a custom extension
+    kubernetes_io = {'google_group_url': None, 'issue_number': None}
+    cve['_kubernetes_io'] = kubernetes_io
+
+    cve['url'] = item['html_url']
+    cve['_kubernetes_io']['issue_number'] = item['number']
+    cve['content_text'] = item['body']
     # This because some CVEs were titled "CVE-XXXX-XXXX - Something" instead of
     # "CVE-XXXX-XXXX: Something" on GitHub (see https://github.com/kubernetes/kubernetes/issues/60813).
-    title = item['title'].replace(" -", ":")
+    title = item['title'].replace(' -', ':')
     # This splits the CVE into its ID and the description/name, however some are in the following forms:
     # - CVE-2019-11245: v1.14.2, v1.13.6: container uid [...] (see https://github.com/kubernetes/kubernetes/issues/78308)
     # - CVE-2019-11250: TOB-K8S-001: Bearer tokens [...] (see https://github.com/kubernetes/kubernetes/issues/81114)
     # We don't know if there are going to be version numbers and/or vendor IDs but the description should be last.
-    title = title.split(": ")
+    title = title.split(': ')
     if len(title) > 0:
-        cve['content_text'] = title[-1]
+        cve['summary'] = title[-1]
         if len(title) > 1:
             cve_id = title[0]
-            cve['cve_id'] = cve_id
-            cve['cve_url'] = f"https://www.cve.org/cverecord?id={cve_id}"
-            cve['google_group_url'] = f"https://groups.google.com/g/kubernetes-announce/search?q={cve_id}"
+            cve['id'] = cve_id
+            cve['external_url'] = f'https://www.cve.org/cverecord?id={cve_id}'
+            cve['_kubernetes_io']['google_group_url'] = f'https://groups.google.com/g/kubernetes-announce/search?q={cve_id}'
     cve_list.append(cve)
 
 cves = json.dumps(cve_list, sort_keys=True, indent=4)
 print(cves)
 # write the final cve list to official_cve_feed.json
-with open("official-cve-feed.json", "w") as cvejson:
+with open('official-cve-feed.json', 'w') as cvejson:
     cvejson.write(cves)

--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -38,7 +38,7 @@ cve_list = []
 for item in gh_items:
     # These keys respects the item jsonfeed spec https://www.jsonfeed.org/version/1.1/
     cve = {'url': None, 'id': None, 'summary': None, 'external_url': None,
-    'content_text': None, '_kubernetes_io': None}
+    'content_text': None, '_kubernetes_io': None, 'date_published': None}
     # This is a custom extension
     kubernetes_io = {'google_group_url': None, 'issue_number': None}
     cve['_kubernetes_io'] = kubernetes_io
@@ -46,6 +46,7 @@ for item in gh_items:
     cve['url'] = item['html_url']
     cve['_kubernetes_io']['issue_number'] = item['number']
     cve['content_text'] = item['body']
+    cve['date_published'] = item['created_at']
     # This because some CVEs were titled "CVE-XXXX-XXXX - Something" instead of
     # "CVE-XXXX-XXXX: Something" on GitHub (see https://github.com/kubernetes/kubernetes/issues/60813).
     title = item['title'].replace(' -', ':')


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/36808.

I simplified the code logically and added documentation on why it's parsing the way it's parsing.
Anecdotally I change all double quotes to single quotes.

I took some arbitrary decisions:
- transform `cve_id` into existing field `id`;
- transform `issue_url` into existing field `url`;
- transform `cve_url` into existing field `external_url`;
- use `_kubernetes_io` as custom extension;
- transform `number` into `issue_number` for clarity.

I didn't add it because it was maybe too much but it would be trivial to add optional fields `date_published` and `date_modified` using GitHub issues metadata.

The CVE feed looks similar to this after the fix (I only used the two last CVEs for the example, note that the indention is not exact):

```json
{
  "version": "https://jsonfeed.org/version/1.1",
  "title": "Auto-refreshing Official CVE Feed",
  "home_page_url": "https://kubernetes.io",
  "feed_url": "https://kubernetes.io/docs/reference/issues-security/official-cve-feed/index.json",
  "description": "Auto-refreshing official CVE feed for Kubernetes repository",
  "authors": [
    {
      "name": "Kubernetes Community",
      "url": "https://www.kubernetes.dev"
    }
  ],
  "items": [
        {
            "_kubernetes_io": {
                "google_group_url": "https://groups.google.com/g/kubernetes-announce/search?q=CVE-2022-3294",
                "issue_number": 113757
            },
            "content_text": "CVSS Rating: [CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H)\r\n\r\nA security issue was discovered in Kubernetes where users may have access to secure endpoints in the control plane network. Kubernetes clusters are only affected if an untrusted user can modify Node objects and send proxy requests to them.\r\n\r\nKubernetes supports node proxying, which allows clients of kube-apiserver to access endpoints of a Kubelet to establish connections to Pods, retrieve container logs, and more. While Kubernetes already validates the proxying address for Nodes, a bug in kube-apiserver made it possible to bypass this validation. Bypassing this validation could allow authenticated requests destined for Nodes to to the API server's private network.\r\n\r\n### Am I vulnerable?\r\n\r\nClusters are affected by this vulnerability if there are endpoints that the kube-apiserver has connectivity to that users should not be able to access. This includes:\r\n\r\n- kube-apiserver is in a separate network from worker nodes\r\n- localhost services\r\n\r\nmTLS services that accept the same client certificate as nodes may be affected. The severity of this issue depends on the privileges & sensitivity of the exploitable endpoints.\r\n\r\nClusters that configure the egress selector to use a proxy for cluster traffic may not be affected.\r\n\r\n\r\n#### Affected Versions\r\n\r\n- Kubernetes kube-apiserver <= v1.25.3\r\n- Kubernetes kube-apiserver <= v1.24.7\r\n- Kubernetes kube-apiserver <= v1.23.13\r\n- Kubernetes kube-apiserver <= v1.22.15\r\n\r\n### How do I mitigate this vulnerability?\r\n\r\nUpgrading the **kube-apiserver** to a fixed version mitigates this vulnerability.\r\n\r\nAside from upgrading, configuring an [egress proxy for egress to the cluster network](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/) can mitigate this vulnerability.\r\n\r\n#### Fixed Versions\r\n\r\n- Kubernetes kube-apiserver v1.25.4\r\n- Kubernetes kube-apiserver v1.24.8\r\n- Kubernetes kube-apiserver v1.23.14\r\n- Kubernetes kube-apiserver v1.22.16\r\n\r\n**Fix impact:** In some cases, the fix can break clients that depend on the nodes/proxy subresource, specifically if a kubelet advertises a localhost or link-local address to the Kubernetes control plane.\r\n\r\n### Detection\r\n\r\nNode create & update requests may be included in the Kubernetes audit log, and can be used to identify requests for IP addresses that should not be permitted. Node proxy requests may also be included in audit logs.\r\n\r\nIf you find evidence that this vulnerability has been exploited, please contact security@kubernetes.io\r\n\r\n#### Acknowledgements\r\n\r\nThis vulnerability was reported by Yuval Avrahami of Palo Alto Networks.\r\n\r\n<!-- labels -->\r\n/area security\r\n/kind bug\r\n/committee security-response\r\n/label official-cve-feed\r\n/sig api-machinery\r\n/area apiserver",
            "external_url": "https://www.cve.org/cverecord?id=CVE-2022-3294",
            "id": "CVE-2022-3294",
            "summary": "Node address isn't always verified when proxying",
            "url": "https://github.com/kubernetes/kubernetes/issues/113757"
        },
        {
            "_kubernetes_io": {
                "google_group_url": "https://groups.google.com/g/kubernetes-announce/search?q=CVE-2022-3162",
                "issue_number": 113756
            },
            "content_text": "CVSS Rating: [CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N)\r\n\r\nA security issue was discovered in Kubernetes where users authorized to list or watch one type of namespaced custom resource cluster-wide can read custom resources of a different type in the same API group without authorization.\r\n\r\n### Am I vulnerable?\r\n\r\nClusters are impacted by this vulnerability if all of the following are true:\r\n- There are 2+ CustomResourceDefinitions sharing the same API group\r\n- Users have cluster-wide list or watch authorization on one of those custom resources.\r\n- The same users are not authorized to read another custom resource in the same API group.\r\n\r\n#### Affected Versions\r\n\r\n- Kubernetes kube-apiserver <= v1.25.3\r\n- Kubernetes kube-apiserver <= v1.24.7\r\n- Kubernetes kube-apiserver <= v1.23.13\r\n- Kubernetes kube-apiserver <= v1.22.15\r\n\r\n### How do I mitigate this vulnerability?\r\n\r\nUpgrading the kube-apiserver to a fixed version mitigates this vulnerability.\r\n\r\nPrior to upgrading, this vulnerability can be mitigated by avoiding granting cluster-wide list and watch permissions.\r\n\r\n#### Fixed Versions\r\n\r\n- Kubernetes kube-apiserver v1.25.4\r\n- Kubernetes kube-apiserver v1.24.8\r\n- Kubernetes kube-apiserver v1.23.14\r\n- Kubernetes kube-apiserver v1.22.16\r\n\r\n### Detection\r\n\r\nRequests containing `..` in the request path are a likely indicator of exploitation. Request paths may be captured in API audit logs, or in kube-apiserver HTTP logs.\r\n\r\nIf you find evidence that this vulnerability has been exploited, please contact security@kubernetes.io\r\n\r\n#### Acknowledgements\r\n\r\nThis vulnerability was reported by Richard Turnbull of NCC Group as part of the Kubernetes Audit.\r\n\r\n<!-- labels -->\r\n/area security\r\n/kind bug\r\n/committee security-response\r\n/label official-cve-feed\r\n/sig api-machinery\r\n/area apiserver\r\n",
            "external_url": "https://www.cve.org/cverecord?id=CVE-2022-3162",
            "id": "CVE-2022-3162",
            "summary": "Unauthorized read of Custom Resources",
            "url": "https://github.com/kubernetes/kubernetes/issues/113756"
        }
    ]
}
```

On a side and useless note, is it useful that the scripts output the JSON dumps? Otherwise, I think it would be more elegant that it just prints to STDOUT the result and that the other bash scripts `python3 script.py > the_file.json`. But this one is really a nit!