### PR TITLE
Fix CVE feed: comply with the JSON feed specifications and add the full JSON feed object in the script output to add `last_updated` root fields

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-cve-feed.sh
+++ b/sig-security-tooling/cve-feed/hack/fetch-cve-feed.sh
@@ -17,17 +17,18 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-#install python-pip3
+# install python-pip3
 apt-get update
 apt-get install -y python3-pip
 
-#install requests module
+# install requests module
 pip3 install requests
 
-#python script to generate official-cve-feed.json 
-python3 fetch-official-cve-feed.py
+# python script to generate official-cve-feed.json 
+# tee duplicates the output from the script to stdout for logs and the JSON file
+python3 fetch-official-cve-feed.py | tee official_cve_feed.json
 
-#function to calculate the hash value of official-cve-feed.json 
+# function to calculate the hash value of official-cve-feed.json 
 calculate_hash(){
     if command -v shasum >/dev/null 2>&1; then
     cat "$@" | shasum -a 256 | cut -d' ' -f1
@@ -39,12 +40,13 @@ calculate_hash(){
     fi
 }
 
-#check if official-cve-feed.json blob exists in the bucket
+# check if official-cve-feed.json blob exists in the bucket
 set -e
 EXIT_CODE=0
 gsutil ls gs://k8s-cve-feed/official-cve-feed.json >/dev/null 2>&1 || EXIT_CODE=$?
 
-#fetch the hash value of existing official-cve-feed.json json, if differs then upload the new cve feed data to the existing blob.
+# fetch the hash value of existing official-cve-feed.json json, if differs then
+# upload the new cve feed data to the existing blob.
 if [[ $EXIT_CODE -eq 1  ]]; then 
     gsutil cp official-cve-feed.json gs://k8s-cve-feed
     calculate_hash official-cve-feed.json > cve-feed-hash

--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -16,6 +16,7 @@
 
 import json
 import requests
+from datetime import datetime
 
 url = 'https://api.github.com/search/issues?q=is:issue+label:official-cve-feed+\
 state:closed+repo:kubernetes/kubernetes&per_page=100'
@@ -33,21 +34,39 @@ while 'next' in res.links:
     res = requests.get(res.links['next']['url'], headers=headers)
     gh_items.extend(res.json()['items'])
 
-cve_list = []
+feed_envelope = {
+    'version': 'https://jsonfeed.org/version/1.1',
+    'title': 'Auto-refreshing Official CVE Feed',
+    'home_page_url': 'https://kubernetes.io',
+    'feed_url': 'https://kubernetes.io/docs/reference/issues-security/official-cve-feed/index.json',
+    'description': 'Auto-refreshing official CVE feed for Kubernetes repository',
+    'authors': [
+        {
+            'name': 'Kubernetes Community',
+            'url': 'https://www.kubernetes.dev'
+        }
+    ],
+    '_kubernetes_io': None,
+    'items': None,
+}
+# format the timestamp the same way as GitHub RFC 3339 timestamps, with only seconds and not milli and microseconds.
+root_kubernetes_io = {'updated_at': datetime.utcnow().isoformat(sep='T', timespec='seconds') + 'Z'}
+feed_envelope['_kubernetes_io'] = root_kubernetes_io
 
+cve_list = []
 for item in gh_items:
     # These keys respects the item jsonfeed spec https://www.jsonfeed.org/version/1.1/
-    cve = {'url': None, 'id': None, 'summary': None, 'external_url': None,
-    'content_text': None, '_kubernetes_io': None, 'date_published': None}
+    cve = {'content_text': None, 'date_published': None, 'external_url': None,
+    'id': None,'summary': None, 'url': None, '_kubernetes_io': None}
     # This is a custom extension
-    kubernetes_io = {'google_group_url': None, 'issue_number': None}
-    cve['_kubernetes_io'] = kubernetes_io
+    item_kubernetes_io = {'google_group_url': None, 'issue_number': None}
+    cve['_kubernetes_io'] = item_kubernetes_io
 
     cve['url'] = item['html_url']
     cve['_kubernetes_io']['issue_number'] = item['number']
     cve['content_text'] = item['body']
     cve['date_published'] = item['created_at']
-    # This because some CVEs were titled "CVE-XXXX-XXXX - Something" instead of
+    # This is because some CVEs were titled "CVE-XXXX-XXXX - Something" instead of
     # "CVE-XXXX-XXXX: Something" on GitHub (see https://github.com/kubernetes/kubernetes/issues/60813).
     title = item['title'].replace(' -', ':')
     # This splits the CVE into its ID and the description/name, however some are in the following forms:
@@ -64,8 +83,6 @@ for item in gh_items:
             cve['_kubernetes_io']['google_group_url'] = f'https://groups.google.com/g/kubernetes-announce/search?q={cve_id}'
     cve_list.append(cve)
 
-cves = json.dumps(cve_list, sort_keys=True, indent=4)
-print(cves)
-# write the final cve list to official_cve_feed.json
-with open('official-cve-feed.json', 'w') as cvejson:
-    cvejson.write(cves)
+feed_envelope['items'] = cve_list
+json_feed = json.dumps(feed_envelope, sort_keys=False, indent=4)
+print(json_feed)

--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -40,25 +40,23 @@ for item in gh_items:
            "summary": None, "cve_url": None, "google_group_url": None}
     cve['issue_url'] = item['html_url']
     cve['number'] = item['number']
+    # This because some CVEs were titled "CVE-XXXX-XXXX - Something" instead of
+    # "CVE-XXXX-XXXX: Something" on GitHub (see https://github.com/kubernetes/kubernetes/issues/60813).
     title = item['title'].replace(" -", ":")
+    # This splits the CVE into its ID and the description/name, however some are in the following forms:
+    # - CVE-2019-11245: v1.14.2, v1.13.6: container uid [...] (see https://github.com/kubernetes/kubernetes/issues/78308)
+    # - CVE-2019-11250: TOB-K8S-001: Bearer tokens [...] (see https://github.com/kubernetes/kubernetes/issues/81114)
+    # We don't know if there are going to be version numbers and/or vendor IDs but the description should be last.
     title = title.split(": ")
-    if len(title) == 1:
-        cve_id = None
-        cve['cve_id'] = None
-        cve['cve_url'] = None
-        cve['summary'] = title[0]
-        cve['google_group_url'] = None
-    else:
-        cve_id = title[0]
-        cve['cve_id'] = title[0]
-        if len(title) == 3:
-            cve['summary'] = title[2]
-        else:
-            cve['summary'] = title[1]
-        cve['cve_url'] = f"https://www.cve.org/cverecord?id={cve_id}"
-        cve['google_group_url'] = \
-        f"https://groups.google.com/g/kubernetes-announce/search?q={cve_id}"
+    if len(title) > 0:
+        cve['content_text'] = title[-1]
+        if len(title) > 1:
+            cve_id = title[0]
+            cve['cve_id'] = cve_id
+            cve['cve_url'] = f"https://www.cve.org/cverecord?id={cve_id}"
+            cve['google_group_url'] = f"https://groups.google.com/g/kubernetes-announce/search?q={cve_id}"
     cve_list.append(cve)
+
 cves = json.dumps(cve_list, sort_keys=True, indent=4)
 print(cves)
 # write the final cve list to official_cve_feed.json

--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -36,29 +36,35 @@ while 'next' in res.links:
 cve_list = []
 
 for item in gh_items:
-    cve = {"issue_url": None, "number": None, "cve_id": None,
-           "summary": None, "cve_url": None, "google_group_url": None}
-    cve['issue_url'] = item['html_url']
-    cve['number'] = item['number']
+    # These keys respects the item jsonfeed spec https://www.jsonfeed.org/version/1.1/
+    cve = {'url': None, 'id': None, 'summary': None, 'external_url': None,
+    'content_text': None, '_kubernetes_io': None}
+    # This is a custom extension
+    kubernetes_io = {'google_group_url': None, 'issue_number': None}
+    cve['_kubernetes_io'] = kubernetes_io
+
+    cve['url'] = item['html_url']
+    cve['_kubernetes_io']['issue_number'] = item['number']
+    cve['content_text'] = item['body']
     # This because some CVEs were titled "CVE-XXXX-XXXX - Something" instead of
     # "CVE-XXXX-XXXX: Something" on GitHub (see https://github.com/kubernetes/kubernetes/issues/60813).
-    title = item['title'].replace(" -", ":")
+    title = item['title'].replace(' -', ':')
     # This splits the CVE into its ID and the description/name, however some are in the following forms:
     # - CVE-2019-11245: v1.14.2, v1.13.6: container uid [...] (see https://github.com/kubernetes/kubernetes/issues/78308)
     # - CVE-2019-11250: TOB-K8S-001: Bearer tokens [...] (see https://github.com/kubernetes/kubernetes/issues/81114)
     # We don't know if there are going to be version numbers and/or vendor IDs but the description should be last.
-    title = title.split(": ")
+    title = title.split(': ')
     if len(title) > 0:
-        cve['content_text'] = title[-1]
+        cve['summary'] = title[-1]
         if len(title) > 1:
             cve_id = title[0]
-            cve['cve_id'] = cve_id
-            cve['cve_url'] = f"https://www.cve.org/cverecord?id={cve_id}"
-            cve['google_group_url'] = f"https://groups.google.com/g/kubernetes-announce/search?q={cve_id}"
+            cve['id'] = cve_id
+            cve['external_url'] = f'https://www.cve.org/cverecord?id={cve_id}'
+            cve['_kubernetes_io']['google_group_url'] = f'https://groups.google.com/g/kubernetes-announce/search?q={cve_id}'
     cve_list.append(cve)
 
 cves = json.dumps(cve_list, sort_keys=True, indent=4)
 print(cves)
 # write the final cve list to official_cve_feed.json
-with open("official-cve-feed.json", "w") as cvejson:
+with open('official-cve-feed.json', 'w') as cvejson:
     cvejson.write(cves)

--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -38,7 +38,7 @@ cve_list = []
 for item in gh_items:
     # These keys respects the item jsonfeed spec https://www.jsonfeed.org/version/1.1/
     cve = {'url': None, 'id': None, 'summary': None, 'external_url': None,
-    'content_text': None, '_kubernetes_io': None}
+    'content_text': None, '_kubernetes_io': None, 'date_published': None}
     # This is a custom extension
     kubernetes_io = {'google_group_url': None, 'issue_number': None}
     cve['_kubernetes_io'] = kubernetes_io
@@ -46,6 +46,7 @@ for item in gh_items:
     cve['url'] = item['html_url']
     cve['_kubernetes_io']['issue_number'] = item['number']
     cve['content_text'] = item['body']
+    cve['date_published'] = item['created_at']
     # This because some CVEs were titled "CVE-XXXX-XXXX - Something" instead of
     # "CVE-XXXX-XXXX: Something" on GitHub (see https://github.com/kubernetes/kubernetes/issues/60813).
     title = item['title'].replace(' -', ':')


### PR DESCRIPTION
This PR bundles another PR https://github.com/kubernetes/sig-security/pull/75. All the changes were included in this one to make it simpler.

This is making modifications to the output of the CVE feed scripts and thus should be synchronized with the merge of an according PR on the k/website side. This is the PR on the k/website site: https://github.com/kubernetes/website/pull/38579.

## This is the content of PR https://github.com/kubernetes/sig-security/pull/75:
Fixes https://github.com/kubernetes/website/issues/36808.

I simplified the code logically and added documentation on why it's parsing the way it's parsing.
Anecdotally I change all double quotes to single quotes.

I took some arbitrary decisions:
- transform `cve_id` into existing field `id`;
- transform `issue_url` into existing field `url`;
- transform `cve_url` into existing field `external_url`;
- use `_kubernetes_io` as custom extension;
- transform `number` into `issue_number` for clarity.

I didn't add it because it was maybe too much but it would be trivial to add optional fields `date_published` and `date_modified` using GitHub issues metadata.

The CVE feed looks similar to this after the fix (I only used the two last CVEs for the example, note that the indention is not exact):

```json
{
  "version": "https://jsonfeed.org/version/1.1",
  "title": "Auto-refreshing Official CVE Feed",
  "home_page_url": "https://kubernetes.io",
  "feed_url": "https://kubernetes.io/docs/reference/issues-security/official-cve-feed/index.json",
  "description": "Auto-refreshing official CVE feed for Kubernetes repository",
  "authors": [
    {
      "name": "Kubernetes Community",
      "url": "https://www.kubernetes.dev"
    }
  ],
  "items": [
        {
            "_kubernetes_io": {
                "google_group_url": "https://groups.google.com/g/kubernetes-announce/search?q=CVE-2022-3294",
                "issue_number": 113757
            },
            "content_text": "CVSS Rating: [CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H)\r\n\r\nA security issue was discovered in Kubernetes where users may have access to secure endpoints in the control plane network. Kubernetes clusters are only affected if an untrusted user can modify Node objects and send proxy requests to them.\r\n\r\nKubernetes supports node proxying, which allows clients of kube-apiserver to access endpoints of a Kubelet to establish connections to Pods, retrieve container logs, and more. While Kubernetes already validates the proxying address for Nodes, a bug in kube-apiserver made it possible to bypass this validation. Bypassing this validation could allow authenticated requests destined for Nodes to to the API server's private network.\r\n\r\n### Am I vulnerable?\r\n\r\nClusters are affected by this vulnerability if there are endpoints that the kube-apiserver has connectivity to that users should not be able to access. This includes:\r\n\r\n- kube-apiserver is in a separate network from worker nodes\r\n- localhost services\r\n\r\nmTLS services that accept the same client certificate as nodes may be affected. The severity of this issue depends on the privileges & sensitivity of the exploitable endpoints.\r\n\r\nClusters that configure the egress selector to use a proxy for cluster traffic may not be affected.\r\n\r\n\r\n#### Affected Versions\r\n\r\n- Kubernetes kube-apiserver <= v1.25.3\r\n- Kubernetes kube-apiserver <= v1.24.7\r\n- Kubernetes kube-apiserver <= v1.23.13\r\n- Kubernetes kube-apiserver <= v1.22.15\r\n\r\n### How do I mitigate this vulnerability?\r\n\r\nUpgrading the **kube-apiserver** to a fixed version mitigates this vulnerability.\r\n\r\nAside from upgrading, configuring an [egress proxy for egress to the cluster network](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/) can mitigate this vulnerability.\r\n\r\n#### Fixed Versions\r\n\r\n- Kubernetes kube-apiserver v1.25.4\r\n- Kubernetes kube-apiserver v1.24.8\r\n- Kubernetes kube-apiserver v1.23.14\r\n- Kubernetes kube-apiserver v1.22.16\r\n\r\n**Fix impact:** In some cases, the fix can break clients that depend on the nodes/proxy subresource, specifically if a kubelet advertises a localhost or link-local address to the Kubernetes control plane.\r\n\r\n### Detection\r\n\r\nNode create & update requests may be included in the Kubernetes audit log, and can be used to identify requests for IP addresses that should not be permitted. Node proxy requests may also be included in audit logs.\r\n\r\nIf you find evidence that this vulnerability has been exploited, please contact security@kubernetes.io\r\n\r\n#### Acknowledgements\r\n\r\nThis vulnerability was reported by Yuval Avrahami of Palo Alto Networks.\r\n\r\n<!-- labels -->\r\n/area security\r\n/kind bug\r\n/committee security-response\r\n/label official-cve-feed\r\n/sig api-machinery\r\n/area apiserver",
            "external_url": "https://www.cve.org/cverecord?id=CVE-2022-3294",
            "id": "CVE-2022-3294",
            "summary": "Node address isn't always verified when proxying",
            "url": "https://github.com/kubernetes/kubernetes/issues/113757"
        },
        {
            "_kubernetes_io": {
                "google_group_url": "https://groups.google.com/g/kubernetes-announce/search?q=CVE-2022-3162",
                "issue_number": 113756
            },
            "content_text": "CVSS Rating: [CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N)\r\n\r\nA security issue was discovered in Kubernetes where users authorized to list or watch one type of namespaced custom resource cluster-wide can read custom resources of a different type in the same API group without authorization.\r\n\r\n### Am I vulnerable?\r\n\r\nClusters are impacted by this vulnerability if all of the following are true:\r\n- There are 2+ CustomResourceDefinitions sharing the same API group\r\n- Users have cluster-wide list or watch authorization on one of those custom resources.\r\n- The same users are not authorized to read another custom resource in the same API group.\r\n\r\n#### Affected Versions\r\n\r\n- Kubernetes kube-apiserver <= v1.25.3\r\n- Kubernetes kube-apiserver <= v1.24.7\r\n- Kubernetes kube-apiserver <= v1.23.13\r\n- Kubernetes kube-apiserver <= v1.22.15\r\n\r\n### How do I mitigate this vulnerability?\r\n\r\nUpgrading the kube-apiserver to a fixed version mitigates this vulnerability.\r\n\r\nPrior to upgrading, this vulnerability can be mitigated by avoiding granting cluster-wide list and watch permissions.\r\n\r\n#### Fixed Versions\r\n\r\n- Kubernetes kube-apiserver v1.25.4\r\n- Kubernetes kube-apiserver v1.24.8\r\n- Kubernetes kube-apiserver v1.23.14\r\n- Kubernetes kube-apiserver v1.22.16\r\n\r\n### Detection\r\n\r\nRequests containing `..` in the request path are a likely indicator of exploitation. Request paths may be captured in API audit logs, or in kube-apiserver HTTP logs.\r\n\r\nIf you find evidence that this vulnerability has been exploited, please contact security@kubernetes.io\r\n\r\n#### Acknowledgements\r\n\r\nThis vulnerability was reported by Richard Turnbull of NCC Group as part of the Kubernetes Audit.\r\n\r\n<!-- labels -->\r\n/area security\r\n/kind bug\r\n/committee security-response\r\n/label official-cve-feed\r\n/sig api-machinery\r\n/area apiserver\r\n",
            "external_url": "https://www.cve.org/cverecord?id=CVE-2022-3162",
            "id": "CVE-2022-3162",
            "summary": "Unauthorized read of Custom Resources",
            "url": "https://github.com/kubernetes/kubernetes/issues/113756"
        }
    ]
}
```

On a side and useless note, is it useful that the scripts output the JSON dumps? Otherwise, I think it would be more elegant that it just prints to STDOUT the result and that the other bash scripts `python3 script.py > the_file.json`. But this one is really a nit!

## This is the old content of this PR:
This resolves https://github.com/kubernetes/sig-security/issues/72.

I don't know if it's the best way to proceed but this PR includes the commits from https://github.com/kubernetes/sig-security/pull/75, so this should be merged into this PR **or better, after**!
Identically, it needs some changes on the k/website side.
/hold

So the unique commit this PR brings is https://github.com/kubernetes/sig-security/commit/e61ffa97873752b9d7fa56b04ea40b87729dc942.
I took the liberty to name it `updated_at`, but we have plenty of possibilities here and maybe we can find something better? Or more in line with the Kubernetes API? I don't know.

/cc @PushkarJ @nehaLohia27