### PR TITLE
Fix a naming issue in CVE feed script

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-cve-feed.sh
+++ b/sig-security-tooling/cve-feed/hack/fetch-cve-feed.sh
@@ -17,6 +17,9 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+# name of the output file
+OUTPUT_FILE=official-cve-feed.json
+
 # install python-pip3
 apt-get update
 apt-get install -y python3-pip
@@ -26,7 +29,7 @@ pip3 install requests
 
 # python script to generate official-cve-feed.json 
 # tee duplicates the output from the script to stdout for logs and the JSON file
-python3 fetch-official-cve-feed.py | tee official_cve_feed.json
+python3 fetch-official-cve-feed.py | tee $OUTPUT_FILE
 
 # function to calculate the hash value of official-cve-feed.json 
 calculate_hash(){
@@ -43,13 +46,13 @@ calculate_hash(){
 # check if official-cve-feed.json blob exists in the bucket
 set -e
 EXIT_CODE=0
-gsutil ls gs://k8s-cve-feed/official-cve-feed.json >/dev/null 2>&1 || EXIT_CODE=$?
+gsutil ls gs://k8s-cve-feed/$OUTPUT_FILE >/dev/null 2>&1 || EXIT_CODE=$?
 
 # fetch the hash value of existing official-cve-feed.json json, if differs then
 # upload the new cve feed data to the existing blob.
 if [[ $EXIT_CODE -eq 1  ]]; then 
-    gsutil cp official-cve-feed.json gs://k8s-cve-feed
-    calculate_hash official-cve-feed.json > cve-feed-hash
+    gsutil cp $OUTPUT_FILE gs://k8s-cve-feed
+    calculate_hash $OUTPUT_FILE > cve-feed-hash
     echo "$(<cve-feed-hash )"
     gsutil cp cve-feed-hash gs://k8s-cve-feed
 else 
@@ -58,7 +61,7 @@ else
     hash=$(<cve-feed-hash )
     echo "old hash value: $hash"
     echo "Calculate the new hash value of json feed"
-    new_hash=$(calculate_hash official-cve-feed.json)
+    new_hash=$(calculate_hash $OUTPUT_FILE)
     echo "new hash value : $new_hash "
     printf "$new_hash" > cve-feed-hash
 
@@ -67,7 +70,7 @@ else
     else
         printf "Both the hash value differ \n"
         echo "Uploading the new json feed and hash value to gcs bucket \n"
-        gsutil cp official-cve-feed.json gs://k8s-cve-feed
+        gsutil cp $OUTPUT_FILE gs://k8s-cve-feed
         gsutil cp cve-feed-hash gs://k8s-cve-feed/cve-feed-hash
     fi
 fi


### PR DESCRIPTION
The, [just merged](https://github.com/kubernetes/sig-security/pull/76), new script is causing failure because of a stupid naming fail (it's my fault) https://testgrid.k8s.io/sig-security-cve-feed#auto-refreshing-official-cve-feed.

I wrote `official_cve_feed.json` instead of `official-cve-feed.json`, which messed up the job.

If someone can lgtm and approve this as soon as possible it would be charming so that I can pursue and continue merging the web side.