### PR TITLE
CVE feed: Add a link to the testgrid.k8s.io prow job as metadata

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -50,7 +50,8 @@ feed_envelope = {
     'items': None,
 }
 # format the timestamp the same way as GitHub RFC 3339 timestamps, with only seconds and not milli and microseconds.
-root_kubernetes_io = {'updated_at': datetime.utcnow().isoformat(sep='T', timespec='seconds') + 'Z'}
+root_kubernetes_io = {'feed_refresh_job': 'https://testgrid.k8s.io/sig-security-cve-feed#auto-refreshing-official-cve-feed',
+                      'updated_at': datetime.utcnow().isoformat(sep='T', timespec='seconds') + 'Z'}
 feed_envelope['_kubernetes_io'] = root_kubernetes_io
 
 cve_list = []


### PR DESCRIPTION
Fixes https://github.com/kubernetes/sig-security/issues/71.

/cc @PushkarJ @nehaLohia27