### PR TITLE
Remove the must be closed requirement in CVE feed

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -19,7 +19,7 @@ import requests
 from datetime import datetime
 
 url = 'https://api.github.com/search/issues?q=is:issue+label:official-cve-feed+\
-state:closed+repo:kubernetes/kubernetes&per_page=100'
+repo:kubernetes/kubernetes&per_page=100'
 
 headers = {'Accept': 'application/vnd.github.v3+json'}
 res = requests.get(url, headers=headers)


### PR DESCRIPTION
The `official-cve-feed` label is sufficient in filtering down to valid issues.

@kubernetes/security-response-committee @kubernetes/sig-security-pr-reviews @PushkarJ

For example, currently https://github.com/kubernetes/kubernetes/issues/121879 is open and published to mitre but not included in the CVE feed which seems like the wrong approach.  We do not add the `official-cve-feed` label until we fill out the issue details, so I do not think there is any need to wait until the issue is closed before including it in the feed.