### PR TITLE
Include CVE status in JSON feed

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -18,6 +18,18 @@ import json
 import requests
 from datetime import datetime
 
+def getCVEStatus(state, state_reason):
+    if state == "open":
+        if state_reason == "reopened":
+            return "unknown"
+        return "open"
+    
+    if state == "closed":
+        if state_reason == "not_planned":
+            return "unfixed"
+        if state_reason == "completed":
+            return "fixed"
+
 url = 'https://api.github.com/search/issues?q=is:issue+label:official-cve-feed+\
 repo:kubernetes/kubernetes&per_page=100'
 
@@ -67,6 +79,7 @@ for item in gh_items:
     cve['_kubernetes_io']['issue_number'] = item['number']
     cve['content_text'] = item['body']
     cve['date_published'] = item['created_at']
+    cve['status'] = getCVEStatus(item['state'], item['state_reason'])
     # This is because some CVEs were titled "CVE-XXXX-XXXX - Something" instead of
     # "CVE-XXXX-XXXX: Something" on GitHub (see https://github.com/kubernetes/kubernetes/issues/60813).
     title = item['title'].replace(' -', ':')


### PR DESCRIPTION
Solves: [#98](https://github.com/kubernetes/sig-security/issues/98)

Results in a new _status_ field being added to each CVE item in the resulting JSON.