### PR TITLE
Handle multiple CVEs per issue in official CVE feed

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import json
 import requests
 from datetime import datetime
@@ -91,10 +92,19 @@ for item in gh_items:
     if len(title) > 0:
         cve['summary'] = title[-1]
         if len(title) > 1:
-            cve_id = title[0]
-            cve['id'] = cve_id
-            cve['external_url'] = f'https://www.cve.org/cverecord?id={cve_id}'
-            cve['_kubernetes_io']['google_group_url'] = f'https://groups.google.com/g/kubernetes-announce/search?q={cve_id}'
+            cve_ids = [cve_id.strip() for cve_id in title[0].split(',')]
+            first_cve_id = cve_ids[0]
+            cve['id'] = first_cve_id
+            cve['external_url'] = f'https://www.cve.org/cverecord?id={first_cve_id}'
+            cve['_kubernetes_io']['google_group_url'] = f'https://groups.google.com/g/kubernetes-announce/search?q={first_cve_id}'
+
+            # Add additional entries for any remaining CVE IDs
+            for additional_cve_id in cve_ids[1:]:
+                additional_cve = copy.deepcopy(cve)
+                additional_cve['id'] = additional_cve_id
+                additional_cve['external_url'] = f'https://www.cve.org/cverecord?id={additional_cve_id}'
+                additional_cve['_kubernetes_io']['google_group_url'] = f'https://groups.google.com/g/kubernetes-announce/search?q={additional_cve_id}'
+                cve_list.append(additional_cve)
     cve_list.append(cve)
 
 feed_envelope['items'] = cve_list


### PR DESCRIPTION
Fix multiple CVE handling in official CVE feed

Fixes https://github.com/kubernetes/website/issues/47003

This change modifies the script used to generate the CVE feed to correctly handle issues containing multiple CVEs. Key updates:

- Create separate entries for each CVE ID when multiple are present in a single issue
- Maintain original structure and behavior for the first CVE entry
- Ensure compatibility with existing feed consumers

This approach aims to resolve the malformed GUID issue while preserving the feed's integrity. Feedback and suggestions for improvement are welcome.

Here is the output from before and after the change:

[before.txt](https://github.com/user-attachments/files/16029574/before.txt)
[after.txt](https://github.com/user-attachments/files/16029570/after.txt)