### PR TITLE
Update CE handle and company.

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,4 +4,4 @@ aliases:
   sig-security-leads:
     - IanColdwater
     - tabbysable
-    - cailynse
+    - cailyn-codes

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 
 * Ian Coldwater (**[@IanColdwater](https://github.com/IanColdwater)**), Docker
 * Tabitha Sable (**[@tabbysable](https://github.com/tabbysable)**), Datadog
-* Cailyn Edwards (**[@cailynse](https://github.com/cailynse)**), Octa
+* Cailyn Edwards (**[@cailyn-codes](https://github.com/cailyn-codes)**), Okta
 
 ## Contact
 - Slack: [#sig-security](https://kubernetes.slack.com/messages/sig-security)


### PR DESCRIPTION
This updates Cailyn's GitHub handle and company name in the SIG Security README. See also https://github.com/kubernetes/org/pull/5233.