### PR TITLE
CVE Feed: Handle recoverable errors

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-cve-feed.sh
+++ b/sig-security-tooling/cve-feed/hack/fetch-cve-feed.sh
@@ -33,8 +33,8 @@ pip3 install requests
 # python script to generate official-cve-feed.json 
 python3 fetch-official-cve-feed.py > "${OUTPUT_FILE}"
 EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-    RETURN_VALUE=$EXIT_CODE
+if [[ "${EXIT_CODE}" -ne 0 ]]; then
+    RETURN_VALUE=${EXIT_CODE}
 fi
 
 # make the prow job logs always helpful
@@ -42,7 +42,7 @@ cat "${OUTPUT_FILE}"
 
 # python returns 7 to indicate recoverable errors
 # Exit bash script now if unrecoverable python error
-if [ $EXIT_CODE -ne 0 ] && [ $EXIT_CODE -ne 7 ]; then
+if [[ "${EXIT_CODE}" -ne 0 ]] && [[ "${EXIT_CODE}" -ne 7 ]]; then
     exit "${RETURN_VALUE}"
 fi
 
@@ -61,31 +61,31 @@ calculate_hash(){
 # check if official-cve-feed.json blob exists in the bucket
 set -e
 EXIT_CODE=0
-gsutil ls gs://k8s-cve-feed/$OUTPUT_FILE >/dev/null 2>&1 || EXIT_CODE=$?
+gsutil ls "gs://k8s-cve-feed/${OUTPUT_FILE}" >/dev/null 2>&1 || EXIT_CODE=$?
 
 # fetch the hash value of existing official-cve-feed.json json, if differs then
 # upload the new cve feed data to the existing blob.
-if [[ $EXIT_CODE -eq 1  ]]; then 
-    gsutil cp $OUTPUT_FILE gs://k8s-cve-feed
-    calculate_hash $OUTPUT_FILE > cve-feed-hash
+if [[ "${EXIT_CODE}" -eq 1  ]]; then 
+    gsutil cp "${OUTPUT_FILE}" gs://k8s-cve-feed
+    calculate_hash "${OUTPUT_FILE}" > cve-feed-hash
     echo "$(<cve-feed-hash )"
     gsutil cp cve-feed-hash gs://k8s-cve-feed
 else 
     echo "Downloading the old hash blob from gcs bucket"
     gsutil cp gs://k8s-cve-feed/cve-feed-hash cve-feed-hash
     hash=$(<cve-feed-hash )
-    echo "old hash value: $hash"
+    echo "old hash value: ${hash}"
     echo "Calculate the new hash value of json feed"
-    new_hash=$(calculate_hash $OUTPUT_FILE)
-    echo "new hash value : $new_hash "
-    printf "$new_hash" > cve-feed-hash
+    new_hash=$(calculate_hash "${OUTPUT_FILE}")
+    echo "new hash value : ${new_hash}"
+    echo "${new_hash}" > cve-feed-hash
 
-    if [[  $hash == $new_hash ]]; then
-        printf "Both the hashes have identical contents"
+    if [[  "${hash}" == "${new_hash}" ]]; then
+        echo "Both the hashes have identical contents"
     else
-        printf "Both the hash value differ \n"
-        echo "Uploading the new json feed and hash value to gcs bucket \n"
-        gsutil cp $OUTPUT_FILE gs://k8s-cve-feed
+        echo "Both the hash value differ"
+        echo "Uploading the new json feed and hash value to gcs bucket"
+        gsutil cp "${OUTPUT_FILE}" gs://k8s-cve-feed
         gsutil cp cve-feed-hash gs://k8s-cve-feed/cve-feed-hash
     fi
 fi


### PR DESCRIPTION
For logging of errors, propagate python script return code through shell to Prow.

This should allow an email to be sent to job maintainers even in the case where the python script continued through a recoverable error.

(Per discussions during SIG Security Tooling working session)