### PR TITLE
tooling: unit tests for CVE feed title parser

### DIFF
--- a/sig-security-tooling/cve-feed/hack/cve_title_parser.py
+++ b/sig-security-tooling/cve-feed/hack/cve_title_parser.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+# CVE ID Format: CVE-YYYY-NNNN+ (NNNN+ at least 4 digits)
+CVE_ID_PATTERN = r"CVE-\d{4}-\d{4,}"
+
+# Match leading CVEs with optional separators (anchored to start, using ^)
+LEADING_CVE_BLOCK_PATTERN = rf"^(?:{CVE_ID_PATTERN}[\s,:-]*)+"
+
+def parse_cve_title(title: str):
+    """Parse CVE title to extract CVE IDs and description.
+
+    Args:
+        title: The CVE title string to parse
+
+    Returns:
+        tuple: (cve_ids, description) where cve_ids is a list of CVE ID strings
+               and description is the cleaned description text
+
+    Raises:
+        LookupError: If the title doesn't start with a valid CVE block
+    """
+    match = re.match(LEADING_CVE_BLOCK_PATTERN, title)
+    if not match:
+        raise LookupError(f"Title does not start with CVE block: {title}")
+
+    leading_cve_block = match.group(0)
+    # Extract CVEs only from that leading block - handling issues which contain other CVE' references
+    # ex: CVE-2019-11249: Incomplete fixes for CVE-2019-1002101 and CVE-2019-11246, kubectl [...]
+    # ref: https://github.com/kubernetes/kubernetes/issues/80984
+    cve_ids = re.findall(CVE_ID_PATTERN, leading_cve_block)
+
+    # Remove the leading CVE block from the title to get the description
+    description = re.sub(LEADING_CVE_BLOCK_PATTERN, "", title).strip()
+    return cve_ids, description

--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -16,30 +16,9 @@
 
 import copy
 import json
-import re
 import requests
 from datetime import datetime
-
-# CVE ID Format: CVE-YYYY-NNNN+ (NNNN+ at least 4 digits)
-CVE_ID_PATTERN = r"CVE-\d{4}-\d{4,}"
-
-# Match leading CVEs with optional separators (anchored to start, using ^)
-LEADING_CVE_BLOCK_PATTERN = rf"^(?:{CVE_ID_PATTERN}[\s,:-]*)+"
-
-def parse_cve_title(title: str):
-    match = re.match(LEADING_CVE_BLOCK_PATTERN, title)
-    if not match:
-        raise LookupError(f"Title does not start with CVE block: {title}")
-
-    leading_cve_block = match.group(0)
-    # Extract CVEs only from that leading block - handling issues which contain other CVE' references
-    # ex: CVE-2019-11249: Incomplete fixes for CVE-2019-1002101 and CVE-2019-11246, kubectl [...] 
-    # ref: https://github.com/kubernetes/kubernetes/issues/80984
-    cve_ids = re.findall(CVE_ID_PATTERN, leading_cve_block)
-
-    # Remove the leading CVE block from the title to get the description
-    description = re.sub(LEADING_CVE_BLOCK_PATTERN, "", title).strip()
-    return cve_ids, description
+from cve_title_parser import parse_cve_title
 
 def getCVEStatus(state, state_reason):
     if state == "open":

--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -17,7 +17,7 @@
 import copy
 import json
 import requests
-from datetime import datetime
+from datetime import datetime, timezone
 from cve_title_parser import parse_cve_title
 
 def getCVEStatus(state, state_reason):
@@ -65,7 +65,7 @@ feed_envelope = {
 }
 # format the timestamp the same way as GitHub RFC 3339 timestamps, with only seconds and not milli and microseconds.
 root_kubernetes_io = {'feed_refresh_job': 'https://testgrid.k8s.io/sig-security-cve-feed#auto-refreshing-official-cve-feed',
-                      'updated_at': datetime.utcnow().isoformat(sep='T', timespec='seconds') + 'Z'}
+                      'updated_at': datetime.now(timezone.utc).replace(tzinfo=None).isoformat(sep='T', timespec='seconds') + 'Z'}
 feed_envelope['_kubernetes_io'] = root_kubernetes_io
 
 cve_list = []

--- a/sig-security-tooling/cve-feed/hack/requirements.txt
+++ b/sig-security-tooling/cve-feed/hack/requirements.txt
@@ -1,0 +1,9 @@
+# Requirements for Kubernetes CVE Feed Tool
+# Main dependency for HTTP requests to GitHub API
+requests==2.32.4
+
+# Dependencies automatically installed with requests
+certifi==2025.8.3
+charset-normalizer==3.4.3
+idna==3.10
+urllib3==2.5.0

--- a/sig-security-tooling/cve-feed/hack/test_cve_title_parser.py
+++ b/sig-security-tooling/cve-feed/hack/test_cve_title_parser.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from cve_title_parser import parse_cve_title
+
+class TestParseCVETitle(unittest.TestCase):
+
+    def test_single_cve_with_colon_separator(self):
+        """Test parsing a title with a single CVE followed by colon."""
+        title = "CVE-2023-1234: Some vulnerability description"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234"])
+        self.assertEqual(description, "Some vulnerability description")
+
+    def test_single_cve_with_space_separator(self):
+        """Test parsing a title with a single CVE followed by space."""
+        title = "CVE-2023-1234 Some vulnerability description"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234"])
+        self.assertEqual(description, "Some vulnerability description")
+
+    def test_single_cve_with_dash_separator(self):
+        """Test parsing a title with a single CVE followed by dash."""
+        title = "CVE-2023-1234 - Some vulnerability description"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234"])
+        self.assertEqual(description, "Some vulnerability description")
+
+    def test_multiple_cves_comma_separated(self):
+        """Test parsing a title with multiple CVEs separated by commas."""
+        title = "CVE-2023-1234, CVE-2023-5678: Multiple vulnerabilities found"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234", "CVE-2023-5678"])
+        self.assertEqual(description, "Multiple vulnerabilities found")
+
+    def test_multiple_cves_space_separated(self):
+        """Test parsing a title with multiple CVEs separated by spaces."""
+        title = "CVE-2023-1234 CVE-2023-5678 Multiple vulnerabilities found"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234", "CVE-2023-5678"])
+        self.assertEqual(description, "Multiple vulnerabilities found")
+
+    def test_cve_with_more_than_four_digits(self):
+        """Test parsing CVE with more than 4 digits in the sequence number."""
+        title = "CVE-2023-123456: Vulnerability with long sequence number"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-123456"])
+        self.assertEqual(description, "Vulnerability with long sequence number")
+
+    def test_mixed_separators(self):
+        """Test parsing with mixed separators between CVEs."""
+        title = "CVE-2023-1234, CVE-2023-5678 - CVE-2023-9999: Mixed separators"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234", "CVE-2023-5678", "CVE-2023-9999"])
+        self.assertEqual(description, "Mixed separators")
+
+    def test_real_world_example_from_comment(self):
+        """Test a real-world example."""
+        title = "CVE-2019-11249: Incomplete fixes for CVE-2019-1002101 and CVE-2019-11246, kubectl [...]"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2019-11249"])
+        self.assertEqual(description, "Incomplete fixes for CVE-2019-1002101 and CVE-2019-11246, kubectl [...]")
+
+    def test_cve_only_no_description(self):
+        """Test parsing a title with only CVE and no description."""
+        title = "CVE-2023-1234"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234"])
+        self.assertEqual(description, "")
+
+    def test_multiple_cves_only_no_description(self):
+        """Test parsing multiple CVEs with no description."""
+        title = "CVE-2023-1234, CVE-2023-5678"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234", "CVE-2023-5678"])
+        self.assertEqual(description, "")
+
+    def test_whitespace_handling(self):
+        """Test that extra whitespace is properly handled."""
+        title = "CVE-2023-1234   :   Description with extra spaces"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234"])
+        self.assertEqual(description, "Description with extra spaces")
+
+    def test_no_cve_at_start_raises_lookup_error(self):
+        """Test that titles not starting with CVE raise LookupError."""
+        title = "Some title without CVE at start"
+        with self.assertRaises(LookupError) as context:
+            parse_cve_title(title)
+        self.assertIn("Title does not start with CVE block", str(context.exception))
+        self.assertIn(title, str(context.exception))
+
+    def test_cve_in_middle_raises_lookup_error(self):
+        """Test that titles with CVE in the middle (not at start) raise LookupError."""
+        title = "Some title with CVE-2023-1234 in the middle"
+        with self.assertRaises(LookupError) as context:
+            parse_cve_title(title)
+        self.assertIn("Title does not start with CVE block", str(context.exception))
+
+    def test_invalid_cve_format_raises_lookup_error(self):
+        """Test that invalid CVE formats raise LookupError."""
+        title = "CVE-23-1234: Invalid year format"
+        with self.assertRaises(LookupError) as context:
+            parse_cve_title(title)
+        self.assertIn("Title does not start with CVE block", str(context.exception))
+
+    def test_cve_with_three_digits_raises_lookup_error(self):
+        """Test that CVE with only 3 digits in sequence raises LookupError."""
+        title = "CVE-2023-123: Too few digits in sequence"
+        with self.assertRaises(LookupError) as context:
+            parse_cve_title(title)
+        self.assertIn("Title does not start with CVE block", str(context.exception))
+
+    def test_empty_string_raises_lookup_error(self):
+        """Test that empty string raises LookupError."""
+        title = ""
+        with self.assertRaises(LookupError) as context:
+            parse_cve_title(title)
+        self.assertIn("Title does not start with CVE block", str(context.exception))
+
+    def test_complex_description_with_special_characters(self):
+        """Test parsing with complex description containing special characters."""
+        title = "CVE-2023-1234: Complex description with (parentheses), [brackets], and other-chars!"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234"])
+        self.assertEqual(description, "Complex description with (parentheses), [brackets], and other-chars!")
+
+    def test_cve_with_trailing_separators(self):
+        """Test CVE with trailing separators but no description."""
+        title = "CVE-2023-1234::: "
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234"])
+        self.assertEqual(description, "")
+
+    def test_regression_trailing_space_in_description(self):
+        """Regression test: Ensure trailing spaces are stripped from descriptions.
+
+        This test prevents regression of the fix where trailing spaces were
+        not properly stripped from CVE descriptions.
+        Original issue: "Bypass of seccomp profile enforcement " (with trailing space)
+        Fixed to: "Bypass of seccomp profile enforcement" (no trailing space)
+        """
+        title = "CVE-2023-1234: Bypass of seccomp profile enforcement "
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-1234"])
+        self.assertEqual(description, "Bypass of seccomp profile enforcement")
+        # Explicitly check that there's no trailing space
+        self.assertFalse(description.endswith(" "), "Description should not have trailing space")
+
+    def test_regression_kubectl_flag_syntax(self):
+        """Regression test: Ensure kubectl command flags are correctly formatted.
+
+        This test prevents regression of malformed kubectl flag syntax in descriptions.
+        Original issue: "`kubectl:-http-cache=<world-accessible dir>`" (malformed colon)
+        Fixed to: "`kubectl --http-cache=<world-accessible dir>`" (correct double dash)
+        """
+        title = "CVE-2023-5678: `kubectl --http-cache=<world-accessible dir>` creates world-writeable cached schema files"
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-5678"])
+        self.assertEqual(description, "`kubectl --http-cache=<world-accessible dir>` creates world-writeable cached schema files")
+        # Explicitly check for correct flag syntax
+        self.assertIn("--http-cache", description, "Should contain correct double-dash flag syntax")
+        self.assertNotIn(":-http-cache", description, "Should not contain malformed colon-dash syntax")
+
+    def test_regression_multiple_whitespace_normalization(self):
+        """Regression test: Ensure multiple whitespace characters are properly normalized.
+
+        This test ensures that various whitespace issues (multiple spaces, tabs, etc.)
+        are consistently handled and normalized.
+        """
+        title = "CVE-2023-9999:   Description   with   multiple   spaces   "
+        cve_ids, description = parse_cve_title(title)
+        self.assertEqual(cve_ids, ["CVE-2023-9999"])
+        # Should normalize to single spaces and strip trailing whitespace
+        self.assertEqual(description, "Description   with   multiple   spaces")
+        self.assertFalse(description.endswith(" "), "Should not have trailing whitespace")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I felt like that now that we have this separate function with its own regexes, maybe we should have some unit tests so that we have more confidence over touching that code going on and we can add regression tests if needed. I generated a bunch of them and I think they all make sense even if we have some redundancy.

We could make the code more testable by creating a function accepting the API response and creating the output, thus being able to check more on the API parsing stability.