### PR TITLE
Add Rory as co-lead for SIG Security Docs subproject

### DIFF
--- a/sig-security-docs/OWNERS
+++ b/sig-security-docs/OWNERS
@@ -2,5 +2,7 @@
 
 reviewers:
   - savitharaghunathan
+  - raesene
 approvers:
   - savitharaghunathan
+  - raesene


### PR DESCRIPTION
Rory has done a fantastic job co-leading SIG Security Docs with @savitharaghunathan for quite a while now! His encouragement of new contributors, kind facilitation, wise guidance, and detailed writing have all helped Kubernetes be safer and easier for our users.

Adding him to the OWNERS file for formal recognition.