### PR TITLE
Add Carol as subproject lead for Self-Assessments

### DIFF
--- a/sig-security-assessments/OWNERS
+++ b/sig-security-assessments/OWNERS
@@ -1,6 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+  - krol3
+
 approvers:
+  - krol3
   - sig-security-leads
 
 emeritus_approvers:


### PR DESCRIPTION
Since May 2025, Carol has been working with the sig-etcd maintainers and SIG Security folks to reopen the SIG Security Self-Assessments process :tada: 

