### PR TITLE
Ref: Update fetch-cve-feed script to output debug logs to stderr

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-cve-feed.sh
+++ b/sig-security-tooling/cve-feed/hack/fetch-cve-feed.sh
@@ -19,6 +19,7 @@ set -o pipefail
 
 # name of the output file
 OUTPUT_FILE=official-cve-feed.json
+STDERR_OUTPUT_FILE=stderr-output.out
 
 # value to return at end of script
 RETURN_VALUE=0
@@ -31,7 +32,7 @@ apt-get install -y python3-pip
 pip3 install requests
 
 # python script to generate official-cve-feed.json 
-python3 fetch-official-cve-feed.py > "${OUTPUT_FILE}"
+python3 fetch-official-cve-feed.py > "${OUTPUT_FILE}" 2> "${STDERR_OUTPUT_FILE}"
 EXIT_CODE=$?
 if [[ "${EXIT_CODE}" -ne 0 ]]; then
     RETURN_VALUE=${EXIT_CODE}
@@ -40,9 +41,12 @@ fi
 # make the prow job logs always helpful
 cat "${OUTPUT_FILE}"
 
-# python returns 7 to indicate recoverable errors
-# Exit bash script now if unrecoverable python error
-if [[ "${EXIT_CODE}" -ne 0 ]] && [[ "${EXIT_CODE}" -ne 7 ]]; then
+# python script returns 7 to indicate recoverable errors
+# exit bash script if unrecoverable error occurs in python script
+if [[ "${EXIT_CODE}" -eq 7 ]]; then
+    echo "Recoverable error (exit code 7) occurred. stderr of script:"
+    cat "${STDERR_OUTPUT_FILE}"
+elif [[ "${EXIT_CODE}" -ne 0 ]]; then
     exit "${RETURN_VALUE}"
 fi
 

--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -18,6 +18,7 @@ import copy
 import json
 import re
 import requests
+import sys
 from datetime import datetime
 
 # CVE ID Format: CVE-YYYY-NNNN+ (NNNN+ at least 4 digits)
@@ -124,11 +125,14 @@ for item in gh_items:
 
         cve_list.append(cve)
     except LookupError:
-        non_parsable_cve_list.append(item['title'])
+        non_parsable_cve_list.append((item['title'], item['html_url']))
 
 feed_envelope['items'] = cve_list
 json_feed = json.dumps(feed_envelope, sort_keys=False, indent=4)
 print(json_feed)
 
 if len(non_parsable_cve_list) != 0:
+    print("Failed to parse below CVE issues:", file=sys.stderr)
+    for title, url in non_parsable_cve_list:
+        print(f"{title}\n{url}", file=sys.stderr)
     exit(7)


### PR DESCRIPTION
### Description

Add debug logs of python script to stderr, so that we can output details of failed parsing cve title to debug later.

### Changes Made

- Update python script to output debug logs about parsing failed issue titles (along with urls).
- Update controller shell script to handle the above debug output.

### Testing

TODO: Will update this.