### PR TITLE
tooling: add README with introduction and links

### DIFF
--- a/sig-security-tooling/README.md
+++ b/sig-security-tooling/README.md
@@ -1,0 +1,30 @@
+# Welcome to SIG security tooling
+
+Our mission is to enhance the security of Kubernetes through
+community-maintained code, often in collaboration with other Special Interest
+Groups (SIGs).
+
+We hold meetings every two weeks on Fridays at 4pm UTC ([check your local
+time](https://mytime.io/4pm/UTC)), typically alternating between working
+sessions and learning sessions. If you’d like to request a learning
+session, please [click here](https://github.com/kubernetes/sig-security/issues/new?assignees=&labels=sig/security&projects=&template=request-learning-session.md&title=REQUEST:+Request+a+Learning+session).
+See the history of learning session in the
+[learning-sessions.md](https://github.com/kubernetes/sig-security/blob/main/sig-security-tooling/learning-sessions.md) file.
+
+## Dashboards
+
+Dashboard for SIG security are defined in
+[kubernetes/test-infra/config/testgrids/kubernetes/sig-security/config.yaml](https://github.com/kubernetes/test-infra/blob/master/config/testgrids/kubernetes/sig-security/config.yaml) and you can find the dashboard group at
+[testgrid.k8s.io/sig-security](https://testgrid.k8s.io/sig-security).
+
+For more information about each project, please refer to the dedicated
+subfolders within this directory.
+
+## Contact us
+
+To join join our meetings, subscribe to the the [kubernetes-sig-security mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-security)
+which will send you calendar invites for the upcoming meetings. For
+asynchronous communication, you can reach us on the
+[Kubernetes sig-security-tooling Slack channel](https://kubernetes.slack.com/messages/sig-security-tooling).
+
+The sub-group owners are listed in the [OWNERS](https://github.com/kubernetes/sig-security/blob/main/sig-security-tooling/OWNERS) file.


### PR DESCRIPTION
So that at least we have a nice page with links to the dashboards as well as a proper introduction about tooling in the GH repo.