### PR TITLE
update OWNERS, pushkarj to emeritus

### DIFF
--- a/sig-security-tooling/OWNERS
+++ b/sig-security-tooling/OWNERS
@@ -1,9 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - pushkarj
   - mtardy
 approvers:
-  - pushkarj
   - mtardy
   - sig-security-leads
+
+emeritus_approvers:
+  - pushkarj


### PR DESCRIPTION
@PushkarJ was the founding subproject lead of SIG Security Tooling. He introduced the CVE feed, snyk scanning, improved the SRC vulnerability publication process, and mentored so many new contributors.

Since he is not currently able to contribute to Kubernetes, and in gratitude for all the good times and hard work, we are moving his OWNERS entry to emeritus status.