### PR TITLE
add introduction section to the official CVE feed README

### DIFF
--- a/sig-security-tooling/cve-feed/README.md
+++ b/sig-security-tooling/cve-feed/README.md
@@ -1,15 +1,42 @@
 # Official CVE Feed
 
-The official CVE feed is separated into two main components:
+## Introduction
+
+The **Kubernetes Official CVE Feed** provides an authoritative and machine-readable source of information about security vulnerabilities (CVEs) affecting Kubernetes.  
+It helps developers, operators, and security professionals stay informed about officially recognized and triaged vulnerabilities in the Kubernetes ecosystem.
+
+This feed is maintained by the **Kubernetes Security Response Committee (SRC)** and **SIG Security**, ensuring that all CVE data published is verified and accurately reflects the current security state of Kubernetes.
+
+### Who Uses the Official CVE Feed
+
+The feed serves multiple audiences:
+
+- **Developers and maintainers** — to identify and track vulnerabilities related to their components or dependencies.  
+- **Security teams and researchers** — to integrate verified Kubernetes CVE data into vulnerability management tools or monitoring systems.  
+- **Cloud providers and Kubernetes distributors** — to automate tracking of upstream advisories and coordinate patching.  
+- **End-users and operators** — to monitor official Kubernetes CVEs and apply security updates or mitigations accordingly.
+
+### What It Provides
+
+- A **JSON feed** listing all issues labeled as [`official-cve-feed`](https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+label%3Aofficial-cve-feed+) in the [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) repository.  
+- An **HTML and RSS view** available at [k8s.io/docs/reference/issues-security/official-cve-feed](https://kubernetes.io/docs/reference/issues-security/official-cve-feed/).  
+
+Each entry in the feed corresponds to an official CVE affecting Kubernetes, such as:  
+- [CVE-2023-5528](https://www.cve.org/CVERecord?id=CVE-2023-5528) — Kubernetes ingress-nginx controller vulnerability  
+- [CVE-2023-3676](https://www.cve.org/CVERecord?id=CVE-2023-3676) — Kubernetes apiserver privilege escalation  
+- [CVE-2021-25741](https://www.cve.org/CVERecord?id=CVE-2021-25741) — Symlink vulnerability in volume mounts  
+
+---
+
+## The official CVE feed is separated into two main components:
 1. The scripts, that update a cloud bucket containing the feed.
 2. The website, rendering and serving the feed in various formats.
 
-## Scripts
+### Scripts
 
 A script in the [kubernetes/sig-security](https://github.com/kubernetes/sig-security)
 repository under the [sig-security-tooling/cve-feed/hack](https://github.com/kubernetes/sig-security/tree/main/sig-security-tooling/cve-feed/hack)
-folder. This script is
-a bash script named `fetch-cve-feed.sh` that:
+folder. This script is a bash script named `fetch-cve-feed.sh` that:
 - sets up the python3 environment;
 - generates the CVE feed file with `fetch-official-cve-feed.py`;
 - compares the sha256 of the newly generated file with the existing one;
@@ -31,7 +58,9 @@ labeled with `official-cve-feed`](https://github.com/kubernetes/kubernetes/issue
 as the input and generate a JSON feed file as an output in a cloud bucket. The
 output can be publicly fetched at [gs://k8s-cve-feed/](https://console.cloud.google.com/storage/browser/k8s-cve-feed) or [storage.googleapis.com/k8s-cve-feed](https://storage.googleapis.com/k8s-cve-feed/).
 
-## Website
+---
+
+### Website
 
 The main output of the official CVE feed is the HTML website page available on
 [k8s.io/docs/reference/issues-security/official-cve-feed](https://kubernetes.io/docs/reference/issues-security/official-cve-feed/)
@@ -46,3 +75,12 @@ which consumes the JSON format by fetching the URL from the
 and translating it to an HTML table.
 
 This page is thus updated every time the website is built.
+
+---
+
+## References
+
+- [Kubernetes Security Response Committee (SRC)](https://kubernetes.io/docs/reference/issues-security/security/#security-response-committee-src)  
+- [Official CVE Feed – Kubernetes Docs](https://kubernetes.io/docs/reference/issues-security/official-cve-feed/)  
+- [Kubernetes CVEs on CVE.org](https://www.cve.org/PartnerInformation/ListofPartners/partner/Kubernetes)  
+- [Google Search: Kubernetes Official CVE Feed](https://www.google.com/search?q=Kubernetes+Official+CVE+Feed)


### PR DESCRIPTION
#### What type of PR is this?
<!-- 
Add one of the following kinds:
 /kind bug
 /kind cleanup
 /kind documentation
 /kind feature

Optionally add one or more of the following kinds if applicable:
 /kind api-change
 /kind deprecation
 /kind failing-test
 /kind flake
 /kind regression
-->
/kind documentation

---

#### What this PR does / why we need it:

This PR adds an **introduction section** to the `README.md` of the **official Kubernetes CVE feed** documentation.  
The new section provides a structured overview explaining what the CVE feed is, who uses it, and what outputs it provides.  
This helps contributors and users understand the purpose, audience, and structure of the CVE feed before diving into technical details.

---

#### Which issue(s) this PR is related to:

Fixes [#141](https://github.com/kubernetes/sig-security/issues/141)

---

#### Special notes for your reviewer:

- The new introduction aligns with the Kubernetes documentation style and tone.  
- Added direct links to example CVEs (e.g., [CVE-2023-5528](https://www.cve.org/CVERecord?id=CVE-2023-5528), [CVE-2023-3676](https://www.cve.org/CVERecord?id=CVE-2023-3676)).  
- The change is limited to documentation and does not affect scripts or functionality.  