### PR TITLE
Fix OWNERS files for sig-security-tooling

### DIFF
--- a/sig-security-tooling/cve-feed/OWNERS
+++ b/sig-security-tooling/cve-feed/OWNERS
@@ -2,8 +2,9 @@
 
 reviewers:
   - mtardy
-  - pushkarj
 approvers:
   - mtardy
-  - pushkarj
   - sig-security-leads
+
+emeritus_approvers:
+  - pushkarj

--- a/sig-security-tooling/cve-feed/OWNERS
+++ b/sig-security-tooling/cve-feed/OWNERS
@@ -1,7 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+  - mtardy
   - pushkarj
 approvers:
+  - mtardy
   - pushkarj
   - sig-security-leads

--- a/sig-security-tooling/vulnerability-mgmt/OWNERS
+++ b/sig-security-tooling/vulnerability-mgmt/OWNERS
@@ -3,6 +3,8 @@
 reviewers:
   - pushkarj
   - ericsmalling
+  - mtardy
 approvers:
   - pushkarj
+  - mtardy
   - sig-security-leads

--- a/sig-security-tooling/vulnerability-mgmt/OWNERS
+++ b/sig-security-tooling/vulnerability-mgmt/OWNERS
@@ -1,10 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - pushkarj
   - ericsmalling
   - mtardy
 approvers:
-  - pushkarj
   - mtardy
   - sig-security-leads
+
+emeritus_approvers:
+  - pushkarj


### PR DESCRIPTION
Update fine-grained OWNERS files to match changes made in https://github.com/kubernetes/sig-security/pull/161 and https://github.com/kubernetes/sig-security/pull/144