### PR TITLE
Update Snyk CLI version per Snyk support

### DIFF
--- a/sig-security-tooling/scanning/build-deps-and-release-images.sh
+++ b/sig-security-tooling/scanning/build-deps-and-release-images.sh
@@ -15,7 +15,8 @@
 
 set -euo pipefail
 apt update && apt -y install jq
-wget -q -O /usr/local/bin/snyk https://static.snyk.io/cli/latest/snyk-linux && chmod +x /usr/local/bin/snyk
+# Hard-coding v1.1296.2 temporarily due to defect in newer versions per Snyk support case number 00123453
+wget -q -O /usr/local/bin/snyk https://static.snyk.io/cli/v1.1296.2/snyk-linux && chmod +x /usr/local/bin/snyk
 mkdir -p "${ARTIFACTS}"
 if [ -z "${SNYK_TOKEN}" ]; then
     echo "SNYK_TOKEN env var is not set, required for snyk scan"


### PR DESCRIPTION
Temporarily hard-code Snyk CLI version to v1.1296.2 due to a defect in newer versions.