### PR TITLE
tooling srctl: add GUI editor support and improve output spacing

### DIFF
--- a/sig-security-tooling/srctl/io.go
+++ b/sig-security-tooling/srctl/io.go
@@ -100,6 +100,11 @@ func ReadFromEditor(number state.StepNumber, value, title, help, example string)
 	// #nosec G204
 	// caution: the binary starts whatever EDITOR is provided by user.
 	cmd := exec.Command(editor, tmpFile.Name())
+	editorFields := strings.Fields(editor)
+	isGuiEditor := len(editorFields) == 2 && (editorFields[1] == "--wait" || editorFields[1] == "-w")
+	if isGuiEditor {
+		cmd = exec.Command(editorFields[0], editorFields[1], tmpFile.Name())
+	}
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/sig-security-tooling/srctl/main.go
+++ b/sig-security-tooling/srctl/main.go
@@ -79,7 +79,7 @@ func Run() error {
 		}
 		// It's important to use %q here to escape any unsafe bytes that
 		// would mess up the terminal output
-		fmt.Printf("%q", pressedKey)
+		fmt.Printf("%q\n", pressedKey)
 
 		// Handle step number keys (0-9, a-b) before the switch
 		if step := state.StepNumberFromASCII(pressedKey); step >= 0 && step < state.StepMax {

--- a/sig-security-tooling/srctl/main.go
+++ b/sig-security-tooling/srctl/main.go
@@ -79,7 +79,7 @@ func Run() error {
 		}
 		// It's important to use %q here to escape any unsafe bytes that
 		// would mess up the terminal output
-		fmt.Printf("%q\n", pressedKey)
+		fmt.Printf("%q", pressedKey)
 
 		// Handle step number keys (0-9, a-b) before the switch
 		if step := state.StepNumberFromASCII(pressedKey); step >= 0 && step < state.StepMax {


### PR DESCRIPTION
Issue:
GUI editors like VS Code open in a new, separate process, so calling programs need GUI editors to be launched with a wait flag to know when the user has finished editing and closed the tab to act on the file. Terminal editors (nano, vim, vi) run directly inside the terminal session, so calling programs automatically wait for the editor process to finish and then act.

Previously there was no handling for an additional arg in the $EDITOR env-var value.

Also, the error and program output would start on the input line and be more difficult to read.

Solutions:
1. Check if the editor var has a flag and if that are is --wait or -w in which case adjust the exec Cmd to move the flag into the command arguements.
2. Add a new-line after the input string. Using \n instead of Println to preserve formatted string print.