### PR TITLE
fix outdated links in vuln mgmt readme

### DIFF
--- a/sig-security-tooling/vulnerability-mgmt/README.md
+++ b/sig-security-tooling/vulnerability-mgmt/README.md
@@ -20,7 +20,7 @@ A tool agnostic periodic scanning of build time dependencies
 be found [here](build-time-dependencies.md)
 
 This track is a partnership between SIG
-Architecture's [Code Organization](https://github.com/kubernetes/community/tree/master/sig-architecture#code-organization)
+Architecture's [Code Organization](https://github.com/kubernetes/community/tree/main/sig-architecture#code-organization)
 sub-project and SIG Security's Tooling sub-project
 
 ### Container Images
@@ -40,13 +40,13 @@ and SIG Security's Tooling sub-project
 
 1. **Responsible disclosure of vulnerabilities**: This will continue to be the
    responsibility
-   of [Security Response Committee](https://github.com/kubernetes/community/tree/master/committee-product-security/README.md)
+   of [Security Response Committee](https://github.com/kubernetes/community/blob/main/committee-security-response/README.md)
 2. **Runtime dependencies**: Triaging of vulnerabilities found in components
    that are runtime dependencies for an on-premises or *-as-a-service*
    Kubernetes deployment. Examples include but are not limited to container
    runtimes, container registries, Node OS
 3. **Resolving license violations**: Allowed third party license policy can be
-   found [here](https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist)
+   found [here](https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md#approved-licenses-for-allowlist)
 4. **Fixing unfixable vulnerabilities**: The focus of this effort is to apply fixes to
 vulnerabilities for which a patch is released by owners of the vulnerable dependency
 or base image. This scoping decision is made to maximize utilization of maintainer


### PR DESCRIPTION
Updated links to working and no-redirect versions.