### PR TITLE
srctl: add the CVSS score and severity in issue/mail template

### DIFF
--- a/sig-security-tooling/srctl/state/email.tmpl
+++ b/sig-security-tooling/srctl/state/email.tmpl
@@ -32,7 +32,7 @@ Hello Kubernetes Community,
 {{- end }}
 {{- if .CVSS.URL }}
 
-This issue has been rated **{{ .CVSS.Severity }}** ([CVSS calculator]({{ .CVSS.URL }}), score: {{ .CVSS.Score }}), and assigned **{{ .CVE }}**
+This issue has been rated **{{ .CVSS.Score }}** ({{ .CVSS.Severity }}) ([CVSS calculator]({{ .CVSS.URL }}), and assigned **{{ .CVE }}**
 {{- else }}
 
 This issue has been assigned **{{ .CVE }}**

--- a/sig-security-tooling/srctl/state/export_test.go
+++ b/sig-security-tooling/srctl/state/export_test.go
@@ -12,7 +12,7 @@ func TestToIssue(t *testing.T) {
 		CVSS: CVSS{
 			URL:      "https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
 			Vector:   "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-			Severity: "High",
+			Severity: "HIGH",
 			Score:    8.8,
 		},
 		Description: "A vulnerability was found in kube-apiserver.",
@@ -37,6 +37,7 @@ func TestToIssue(t *testing.T) {
 
 	expectedStrings := []string{
 		"ISSUE TITLE: `CVE-2024-1234: Buffer overflow in kube-apiserver`",
+		"CVSS Rating: **8.8** (HIGH)",
 		"CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
 		"A vulnerability was found in kube-apiserver.",
 		"### Am I vulnerable?",
@@ -74,7 +75,7 @@ func TestToEmail(t *testing.T) {
 		CVSS: CVSS{
 			URL:      "https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
 			Vector:   "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-			Severity: "High",
+			Severity: "HIGH",
 			Score:    8.8,
 		},
 		Description: "A vulnerability was found in kube-apiserver.",
@@ -102,9 +103,8 @@ func TestToEmail(t *testing.T) {
 		"SUBJECT: `[kubernetes] CVE-2024-1234: Buffer overflow in kube-apiserver`",
 		"Hello Kubernetes Community,",
 		"A vulnerability was found in kube-apiserver.",
-		"**High**",
+		"**8.8** (HIGH)",
 		"[CVSS calculator](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H)",
-		"score: 8.8",
 		"### Am I vulnerable?",
 		"Clusters running kube-apiserver versions below v1.31.12 are affected.",
 		"#### Affected Versions",
@@ -140,7 +140,7 @@ func TestToSlack(t *testing.T) {
 		CVSS: CVSS{
 			URL:      "https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
 			Vector:   "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-			Severity: "High",
+			Severity: "HIGH",
 			Score:    8.8,
 		},
 	}
@@ -153,7 +153,7 @@ func TestToSlack(t *testing.T) {
 	result := string(output)
 
 	expectedStrings := []string{
-		"**High**",
+		"**8.8** (HIGH)",
 		"**CVE-2024-1234**",
 	}
 

--- a/sig-security-tooling/srctl/state/issue.tmpl
+++ b/sig-security-tooling/srctl/state/issue.tmpl
@@ -6,7 +6,7 @@ ISSUE TITLE: `{{ .CVE }}{{ if .Summary }}: {{ .Summary }}{{ end}}`
 
 ---
 {{ if .CVSS.URL }}
-CVSS Rating: [{{ .CVSS.Vector }}]({{ .CVSS.URL }})
+CVSS Rating: **{{ .CVSS.Score }}** ({{ .CVSS.Severity }}) [{{ .CVSS.Vector }}]({{ .CVSS.URL }})
 {{- end }}
 
 {{- if .Description }}

--- a/sig-security-tooling/srctl/state/slack.tmpl
+++ b/sig-security-tooling/srctl/state/slack.tmpl
@@ -2,4 +2,4 @@
 
 This message should be posted to the `#announcements` channel, which requires special permissions. -->
 
-The Security Response Committee has posted a security advisory{{ if .Versions }} for {{ (index .Versions 0).Component }}{{ end }}{{ if .Summary }} that {{ .Summary }}{{ end }}. This issue has been rated **{{ .CVSS.Severity }}** and assigned **{{ .CVE }}**.{{ if .GitHubIssue.URL }} Please see {{ .GitHubIssue.URL }} for more details.{{ end }}
+The Security Response Committee has posted a security advisory{{ if .Versions }} for {{ (index .Versions 0).Component }}{{ end }}{{ if .Summary }} that {{ .Summary }}{{ end }}. This issue has been rated **{{ .CVSS.Score }}** ({{ .CVSS.Severity }}) and assigned **{{ .CVE }}**.{{ if .GitHubIssue.URL }} Please see {{ .GitHubIssue.URL }} for more details.{{ end }}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/sig-security/issues/187

It was missing mostly from the issue template. Also uniformize how the score is presented. Let's do the actual score in bold, then the severity in parenthesis (it will be in uppercase) and then the link with CVSS vector.
