### PR TITLE
srctl: fix affected versions templating in email

### DIFF
--- a/sig-security-tooling/srctl/state/email.tmpl
+++ b/sig-security-tooling/srctl/state/email.tmpl
@@ -47,7 +47,7 @@ This issue has been assigned **{{ .CVE }}**
 
 #### Affected Versions
 {{ range .Versions }}
-- {{ .Component }}: {{ if .FirstAffectedVersion }}{{ .FirstAffectedVersion }}{{ end }}{{ if and .FirstAffectedVersion .FixedVersion }} < {{ end }}{{ if .FixedVersion }}{{ .FixedVersion }}{{ end }}
+- {{ .Component }}: {{ if .FirstAffectedVersion }}{{ .FirstAffectedVersion }} {{ end }}< {{ .FixedVersion }}
 {{- end }}
 {{- end }}
 

--- a/sig-security-tooling/srctl/state/export_test.go
+++ b/sig-security-tooling/srctl/state/export_test.go
@@ -188,6 +188,26 @@ func TestToEmailWithoutCVSS(t *testing.T) {
 	}
 }
 
+func TestToEmailAffectedVersionsFormat(t *testing.T) {
+	// Regression test: old template only showed '<' when both FirstAffectedVersion and FixedVersion existed
+	data := CVEData{
+		CVE: "CVE-2024-1234",
+		Versions: []Versions{
+			{Component: "kube-apiserver", FirstAffectedVersion: "", FixedVersion: "v1.31.12"},
+		},
+	}
+
+	output, err := data.ToEmail()
+	if err != nil {
+		t.Fatalf("ToEmail() error: %v", err)
+	}
+
+	result := string(output)
+	if !strings.Contains(result, "kube-apiserver: < v1.31.12") {
+		t.Error("ToEmail() should show '<' even when FirstAffectedVersion is empty")
+	}
+}
+
 func TestToIssueMinimalData(t *testing.T) {
 	data := CVEData{
 		CVE:      "CVE-2024-9999",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/sig-security/issues/186.

Also add a regression test for this.