### PR TITLE
srctl: fix vanity import path in go.mod

### DIFF
--- a/sig-security-tooling/srctl/go.mod
+++ b/sig-security-tooling/srctl/go.mod
@@ -1,4 +1,4 @@
-module k8s.io/kubernetes/sig-security/srctl
+module k8s.io/sig-security/sig-security-tooling/srctl
 
 go 1.25.3
 


### PR DESCRIPTION
So that go install would work:

	go install k8s.io/sig-security/sig-security-tooling/srctl@latest

By checking with:

	curl -sL "https://k8s.io/sig-security/sig-security-tooling/srctl?go-get=1"

The output should be similar to:

       <html><head>
                  <meta name="go-import"
                        content="k8s.io/sig-security
                                 git https://github.com/kubernetes/sig-security">
                  <meta name="go-source"
                        content="k8s.io/sig-security
                                 https://github.com/kubernetes/sig-security
                                 https://github.com/kubernetes/sig-security/tree/master{/dir}
                                 https://github.com/kubernetes/sig-security/blob/master{/dir}/{file}#L{line}">
            </head></html>

You can see that the k8s.io/sig-security does redirect to https://github.com/kubernetes/sig-security.