### PR TITLE
tooling: snyk: install gpgv explicitly

### DIFF
--- a/sig-security-tooling/scanning/install-snyk-cli.sh
+++ b/sig-security-tooling/scanning/install-snyk-cli.sh
@@ -33,7 +33,7 @@ snyk_key_fingerprint="467717A30B2B4658415975629691DA64D0025194"
 snyk_cli_version="1.1305.0" # 1.1305.0 is the latest stable version as of 2026-06-17
 
 set -euo pipefail
-apt update && apt -y install curl gnupg
+apt update && apt -y install curl gnupg gpgv
 
 tmpdir=$(mktemp -d)
 gpghome="${tmpdir}/gnupg"


### PR DESCRIPTION
gnupg only appears to [recommend gpgv](https://packages.debian.org/sid/gnupg), but won't install it automatically.

https://testgrid.k8s.io/sig-security-snyk-scan#ci-kubernetes-snyk-master appears to be permafailing for a while because of this missing dependency.