### PR TITLE
Update meeting schedule for SIG Security Tooling subgroup

### DIFF
--- a/sig-security-tooling/README.md
+++ b/sig-security-tooling/README.md
@@ -4,8 +4,8 @@ Our mission is to enhance the security of Kubernetes through
 community-maintained code, often in collaboration with other Special Interest
 Groups (SIGs).
 
-We hold meetings every two weeks on Fridays at 4pm UTC ([check your local
-time](https://mytime.io/4pm/UTC)), typically alternating between working
+We hold meetings every two weeks on Wednesdays at 5pm UTC ([check your local
+time](https://mytime.io/5pm/UTC)), typically alternating between working
 sessions and learning sessions. If you’d like to request a learning
 session, please [click here](https://github.com/kubernetes/sig-security/issues/new?assignees=&labels=sig/security&projects=&template=request-learning-session.md&title=REQUEST:+Request+a+Learning+session).
 See the history of learning session in the
@@ -13,7 +13,7 @@ See the history of learning session in the
 
 ## Dashboards
 
-Dashboard for SIG security are defined in
+Dashboards for SIG security are defined in
 [kubernetes/test-infra/config/testgrids/kubernetes/sig-security/config.yaml](https://github.com/kubernetes/test-infra/blob/master/config/testgrids/kubernetes/sig-security/config.yaml) and you can find the dashboard group at
 [testgrid.k8s.io/sig-security](https://testgrid.k8s.io/sig-security).
 
@@ -22,7 +22,7 @@ subfolders within this directory.
 
 ## Contact us
 
-To join join our meetings, subscribe to the the [kubernetes-sig-security mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-security)
+To join our meetings, subscribe to the [kubernetes-sig-security mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-security)
 which will send you calendar invites for the upcoming meetings. For
 asynchronous communication, you can reach us on the
 [Kubernetes sig-security-tooling Slack channel](https://kubernetes.slack.com/messages/sig-security-tooling).


### PR DESCRIPTION
This PR updates the meeting schedule for SIG Security Tooling sub group according to decision from Aug 1st 2026. 

PS: Readme still instructs contributors to subscribe to [kubernetes-sig-security mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-security) in order to join meetings. Is this still the way? Or any new suggested ways of getting the calendar?

Other updates: 
[x] https://docs.google.com/document/d/1GgmmNYN88IZ2v2NBiO3gdU8Riomm0upge_XNVxEYXp0/edit?tab=t.0#heading=h.ilkdguo0vv8t 
[x] https://docs.google.com/document/d/1_Rn7S8UPMtXdu6EDl4_L2Ogb433z7hlxPs7El8TfNNg/edit?tab=t.0
[ ] TODO: Shared Calendar https://calendar.google.com/?cid=gcrv7mhqvgdsi08e3bm46l914c%40group.calendar.google.com