### PR TITLE
cve-feed: print more debug information on GitHub req issues

### DIFF
--- a/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
+++ b/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py
@@ -33,12 +33,26 @@ def getCVEStatus(state, state_reason):
         if state_reason == "completed":
             return "fixed"
 
+def get_github_json(res):
+    """Parse GitHub API response with error handling."""
+    if res.status_code != 200:
+        print(f"GitHub API returned status {res.status_code}", file=sys.stderr)
+        print(f"Headers: {dict(res.headers)}", file=sys.stderr)
+        print(f"Body: {res.text}", file=sys.stderr)
+        exit(1)
+    try:
+        return res.json()
+    except Exception as e:
+        print(f"Failed to parse response: {e}", file=sys.stderr)
+        print(f"Status: {res.status_code}, Body: {res.text}", file=sys.stderr)
+        exit(1)
+
 url = 'https://api.github.com/search/issues?q=is:issue+label:official-cve-feed+\
 repo:kubernetes/kubernetes&per_page=100'
 
 headers = {'Accept': 'application/vnd.github.v3+json'}
 res = requests.get(url, headers=headers)
-gh_items = res.json()['items']
+gh_items = get_github_json(res)['items']
 # Use link header to iterate over pages
 # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#pagination
 # https://datatracker.ietf.org/doc/html/rfc5988
@@ -47,7 +61,7 @@ gh_items = res.json()['items']
 # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
 while 'next' in res.links:
     res = requests.get(res.links['next']['url'], headers=headers)
-    gh_items.extend(res.json()['items'])
+    gh_items.extend(get_github_json(res)['items'])
 
 feed_envelope = {
     'version': 'https://jsonfeed.org/version/1.1',


### PR DESCRIPTION
Currently it's tricky to understand what happened:

	Traceback (most recent call last):
	  File "/usr/local/lib/python3.9/dist-packages/requests/models.py", line 976, in json
	    return complexjson.loads(self.text, **kwargs)
	  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
	    return _default_decoder.decode(s)
	  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
	    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
	  File "/usr/lib/python3.9/json/decoder.py", line 355, in raw_decode
	    raise JSONDecodeError("Expecting value", s, err.value) from None
	json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

	During handling of the above exception, another exception occurred:

	Traceback (most recent call last):
	  File "/home/prow/go/src/github.com/kubernetes/sig-security/sig-security-tooling/cve-feed/hack/fetch-official-cve-feed.py", line 41, in <module>
	    gh_items = res.json()['items']
	  File "/usr/local/lib/python3.9/dist-packages/requests/models.py", line 980, in json
	    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
	requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)